### PR TITLE
Implement additional caching and improve releasing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,26 +26,75 @@ on:
         description: 'Build Windows ARM64'
         type: boolean
         default: true
-      create_release:
-        description: 'Create GitHub Release'
-        type: boolean
-        default: false
 
-# Cancel previous runs on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum Node.js version (matches package.json engines)
   NODE_VERSION: '20'
+  TAURI_CLI_VERSION: '^2'
 
 jobs:
+  create-release:
+    name: Create draft release (early)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_tag: ${{ steps.relmeta.outputs.tag }}
+      release_name: ${{ steps.relmeta.outputs.name }}
+    steps:
+      - name: Compute release tag/name (start at v1.0.0)
+        id: relmeta
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+            NAME="${GITHUB_REF_NAME}"
+          else
+            # Get latest release tag (if any)
+            LAST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)
+
+            if [[ -z "$LAST_TAG" ]]; then
+              TAG="v1.0.0"
+            else
+              # Expect vMAJOR.MINOR.PATCH
+              IFS='.' read -r MAJOR MINOR PATCH <<<"${LAST_TAG#v}"
+              PATCH=$((PATCH + 1))
+              TAG="v${MAJOR}.${MINOR}.${PATCH}"
+            fi
+
+            NAME="$TAG"
+          fi
+
+          echo "tag=$TAG" >>"$GITHUB_OUTPUT"
+          echo "name=$NAME" >>"$GITHUB_OUTPUT"
+
+      - name: Create/Update GitHub Release (draft ${{ steps.relmeta.outputs.tag }})
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.relmeta.outputs.tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          commit: ${{ github.sha }}
+          draft: true
+          prerelease: false
+          generateReleaseNotes: true
+          allowUpdates: true
+          replacesArtifacts: false
+
   build-linux-x64:
     name: build-linux (x86_64-unknown-linux-gnu)
+    needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_linux_x64 }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -75,65 +124,115 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Cache cargo bin (tauri-cli)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install npm dependencies
         run: npm ci
 
       - name: Build frontend
         run: npm run build
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - name: Install Tauri CLI (if missing)
+        shell: bash
+        run: |
+          if ! command -v cargo-tauri >/dev/null 2>&1; then
+            cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+          fi
 
       - name: Build Tauri app
         run: cargo tauri build --bundles deb
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload .deb to GitHub Release
+        uses: ncipollo/release-action@v1
         with:
-          name: linux-x64
-          path: |
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          draft: true
+          prerelease: false
+          generateReleaseNotes: false
+          allowUpdates: true
+          replacesArtifacts: false
+          artifacts: |
             src-tauri/target/release/bundle/deb/*.deb
-          if-no-files-found: error
 
   build-linux-arm64:
     name: build-linux (aarch64-unknown-linux-gnu)
+    needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_linux_arm64 }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - name: Build in Docker (ARM64)
+      - name: Install dependencies
         run: |
-          docker run --rm --platform linux/arm64 \
-            -v "${{ github.workspace }}:/app" \
-            -w /app \
-            rust:bookworm \
-            bash -c '
-              apt-get update && apt-get install -y \
-                libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-                librsvg2-dev patchelf libssl-dev libgtk-3-dev \
-                squashfs-tools pkg-config nodejs npm && \
-              npm ci && \
-              npm run build && \
-              cargo install tauri-cli --version "^2" --locked && \
-              cargo tauri build --bundles deb
-            '
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            squashfs-tools
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          name: linux-arm64
-          path: |
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Cache cargo bin (tauri-cli)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Install Tauri CLI (if missing)
+        shell: bash
+        run: |
+          if ! command -v cargo-tauri >/dev/null 2>&1; then
+            cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+          fi
+
+      - name: Build Tauri app
+        run: cargo tauri build --bundles deb
+
+      - name: Upload .deb to GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          draft: true
+          prerelease: false
+          generateReleaseNotes: false
+          allowUpdates: true
+          replacesArtifacts: false
+          artifacts: |
             src-tauri/target/release/bundle/deb/*.deb
-          if-no-files-found: error
 
   build-macos:
     name: build-macos (${{ matrix.target }})
+    needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_macos }}
     strategy:
       fail-fast: false
@@ -147,6 +246,9 @@ jobs:
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -156,13 +258,23 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
-      - name: Setup Rust
+      - name: Setup Rust (add target)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # ensure cache separation per target
+          key: macos-${{ matrix.target }}
+
+      - name: Cache cargo bin (tauri-cli)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install npm dependencies
         run: npm ci
@@ -170,33 +282,63 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - name: Install Tauri CLI (if missing)
+        shell: bash
+        run: |
+          if ! command -v cargo-tauri >/dev/null 2>&1; then
+            cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+          fi
 
-      - name: Build Tauri app
-        run: cargo tauri build --bundles dmg,app
+      - name: Build Tauri app (per-target output dir)
+        shell: bash
+        run: |
+          cargo tauri build --target "${{ matrix.target }}" --bundles dmg,app
 
       - name: Ad-hoc sign the app
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: src-tauri/target/${{ matrix.target }}
         run: |
-          APP_PATH=$(find src-tauri/target/release/bundle/macos -name "*.app" -type d | head -1)
+
+          APP_PATH=$(find "$CARGO_TARGET_DIR/release/bundle/macos" -name "*.app" -type d | head -1)
           if [ -n "$APP_PATH" ]; then
             echo "Ad-hoc signing: $APP_PATH"
             codesign --force --deep --sign - "$APP_PATH"
           fi
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Zip .app bundle(s)
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: src-tauri/target/${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for app in "$CARGO_TARGET_DIR/release/bundle/macos/"*.app; do
+            base="$(basename "$app" .app)"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$CARGO_TARGET_DIR/release/bundle/macos/${base}-${{ matrix.arch }}.app.zip"
+          done
+
+      - name: Upload macOS artifacts to GitHub Release
+        uses: ncipollo/release-action@v1
         with:
-          name: macos-${{ matrix.arch }}
-          path: |
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/bundle/macos/*.app
-          if-no-files-found: error
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          draft: true
+          prerelease: false
+          generateReleaseNotes: false
+          allowUpdates: true
+          replacesArtifacts: false
+          artifacts: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*-${{ matrix.arch }}.app.zip
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
 
   build-windows-x64:
     name: build-windows (x86_64-pc-windows-msvc)
+    needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_windows_x64 }}
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -214,31 +356,51 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Cache cargo bin (tauri-cli)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~\.cargo\bin
+          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install npm dependencies
         run: npm ci
 
       - name: Build frontend
         run: npm run build
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - name: Install Tauri CLI (if missing)
+        shell: bash
+        run: |
+          if ! command -v cargo-tauri >/dev/null 2>&1; then
+            cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+          fi
 
       - name: Build Tauri app
         run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi,nsis
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload artifacts to GitHub Release
+        uses: ncipollo/release-action@v1
         with:
-          name: windows-x64
-          path: |
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          draft: true
+          prerelease: false
+          generateReleaseNotes: false
+          allowUpdates: true
+          replacesArtifacts: false
+          artifacts: |
             src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
             src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
-          if-no-files-found: error
 
   build-windows-arm64:
     name: build-windows (aarch64-pc-windows-msvc)
+    needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_windows_arm64 }}
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -258,66 +420,72 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Cache cargo bin (tauri-cli)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~\.cargo\bin
+          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install npm dependencies
         run: npm ci
 
       - name: Build frontend
         run: npm run build
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - name: Install Tauri CLI (if missing)
+        shell: bash
+        run: |
+          if ! command -v cargo-tauri >/dev/null 2>&1; then
+            cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+          fi
 
       - name: Build Tauri app
         run: cargo tauri build --target aarch64-pc-windows-msvc --bundles msi,nsis
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload artifacts to GitHub Release
+        uses: ncipollo/release-action@v1
         with:
-          name: windows-arm64
-          path: |
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          draft: true
+          prerelease: false
+          generateReleaseNotes: false
+          allowUpdates: true
+          replacesArtifacts: false
+          artifacts: |
             src-tauri/target/aarch64-pc-windows-msvc/release/bundle/msi/*.msi
             src-tauri/target/aarch64-pc-windows-msvc/release/bundle/nsis/*.exe
-          if-no-files-found: error
 
-  release:
-    needs: [build-linux-x64, build-linux-arm64, build-macos, build-windows-x64, build-windows-arm64]
-    # Run if: (tag push) OR (manual dispatch with create_release=true AND all builds succeeded)
+  finalize-release:
+    name: Publish release (draft -> false) + cleanup
+    needs:
+      - create-release
+      - build-linux-x64
+      - build-linux-arm64
+      - build-macos
+      - build-windows-x64
+      - build-windows-arm64
     if: |
       always() &&
-      (startsWith(github.ref, 'refs/tags/v') || inputs.create_release) &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -la artifacts/**/* || echo "No artifacts found"
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          generate_release_notes: true
-          tag_name: ${{ github.ref_name || 'manual-build' }}
-          files: |
-            artifacts/**/*.deb
-            artifacts/**/*.dmg
-            artifacts/**/*.msi
-            artifacts/**/*.exe
-
-  cleanup:
-    name: Cleanup old workflow runs
-    runs-on: ubuntu-latest
-    permissions:
       actions: write
     steps:
+      - name: Publish GitHub Release (set draft=false)
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.create-release.outputs.release_tag }}
+          name: "Armbian Imager ${{ needs.create-release.outputs.release_tag }}"
+          allowUpdates: true
+          draft: false
+          prerelease: false
+
       - name: Delete old workflow runs
         uses: Mattraks/delete-workflow-runs@v2
         with:


### PR DESCRIPTION
## Summary

This PR refactors the release workflow and make builds faster, more reliable, and release-centric, while simplifying artifact handling.

## Key Changes

- Upload build artifacts **directly to the release** from each job
- Introduce automatic semantic versioning starting at **`v1.0.0`**
- Tag pushes (`v*`) continue to publish using the provided tag

### Build architecture cleanup
- Drop QEMU and Docker-based ARM emulation
- Use **native ARM64 runners** (`ubuntu-24.04-arm`) for Linux ARM builds

### Performance & reliability
- Retain effective caching:
  - npm cache via `actions/setup-node`
  - Cargo registry/target cache via `Swatinem/rust-cache`
  - Cached `tauri-cli` binary to avoid repeated installs

###  Platform-specific handling
- macOS `.app` bundles are zipped before attaching to releases (GitHub releases require files)
- Linux, Windows, and macOS artifacts are attached incrementally as builds complete

### Cleanup & maintenance
- Cleanup of old workflow runs is executed **after release finalization**
- Ensures release publishing is not affected by cleanup logic

## Result

- Faster CI runs (no artifact shuffling, no emulation)
- Deterministic, reproducible releases
- Clean semantic versioning starting at **v1.0.0** (if no other tag set)