### PR TITLE
Add macOS ad-hoc signing and first launch instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,6 +292,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    env:
+      # Ad-hoc signing: allows app to run after "xattr -cr" on macOS
+      APPLE_SIGNING_IDENTITY: "-"
 
     steps:
       - uses: actions/checkout@v4
@@ -359,18 +362,6 @@ jobs:
         shell: bash
         run: |
           cargo tauri build --target "${{ matrix.target }}" --bundles dmg,app
-
-      - name: Ad-hoc sign the app
-        shell: bash
-        env:
-          CARGO_TARGET_DIR: src-tauri/target/${{ matrix.target }}
-        run: |
-
-          APP_PATH=$(find "$CARGO_TARGET_DIR/release/bundle/macos" -name "*.app" -type d | head -1)
-          if [ -n "$APP_PATH" ]; then
-            echo "Ad-hoc signing: $APP_PATH"
-            codesign --force --deep --sign - "$APP_PATH"
-          fi
 
       - name: Zip .app bundle(s)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -39,9 +39,22 @@
 |:---:|:---:|:---:|
 | **macOS** | **Windows** | **Linux** |
 | [Intel & Apple Silicon](https://github.com/armbian/imager/releases) | [x64 & ARM64](https://github.com/armbian/imager/releases) | [x64 & ARM64](https://github.com/armbian/imager/releases) |
-| `.dmg` | `.exe` / `.msi` | `.deb` |
+| `.dmg` / `.app.zip` | `.exe` / `.msi` | `.deb` |
 
 </p>
+
+### macOS: First Launch
+
+macOS may show a warning because the app is not signed with an Apple Developer certificate. To open it:
+
+**Option 1:** Right-click the app → **Open** → Click **Open** in the dialog
+
+**Option 2:** Run in Terminal:
+```bash
+xattr -cr "/Applications/Armbian Imager.app"
+```
+
+This only needs to be done once.
 
 ## How It Works
 


### PR DESCRIPTION

Fixes the "app is damaged" error on macOS when downloading builds from GitHub releases.

## Changes

1. Add APPLE_SIGNING_IDENTITY="-" to macOS CI builds for ad-hoc code signing
2. Update README with macOS first launch instructions (right-click → Open or xattr -cr)

## How it works

Without an Apple Developer certificate ($99/year), macOS Gatekeeper blocks apps downloaded from the internet. Ad-hoc signing allows the app to run after the user bypasses Gatekeeper once via right-click → Open or by removing the quarantine attribute.