### PR TITLE
Add update check modal with i18n support

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import armbianLogo from '../assets/armbian-logo.png';
 import type { BoardInfo, ImageInfo, BlockDevice } from '../types';
 import type { Manufacturer } from './ManufacturerModal';
+import { UpdateModal } from './shared/UpdateModal';
 
 interface HeaderProps {
   selectedManufacturer?: Manufacturer | null;
@@ -34,20 +35,23 @@ export function Header({
       ];
 
   return (
-    <header className="header">
-      <div className="header-left">
-        <img src={armbianLogo} alt="Armbian" className="logo-main" />
-      </div>
-      <div className="header-steps">
-        {steps.map((step, index) => (
-          <div key={step.label} className={`header-step ${step.completed ? 'completed' : ''}`}>
-            <span className="header-step-indicator">
-              {step.completed ? <Check size={14} /> : (index + 1)}
-            </span>
-            <span className="header-step-label">{step.label}</span>
-          </div>
-        ))}
-      </div>
-    </header>
+    <>
+      <UpdateModal />
+      <header className="header">
+        <div className="header-left">
+          <img src={armbianLogo} alt="Armbian" className="logo-main" />
+        </div>
+        <div className="header-steps">
+          {steps.map((step, index) => (
+            <div key={step.label} className={`header-step ${step.completed ? 'completed' : ''}`}>
+              <span className="header-step-indicator">
+                {step.completed ? <Check size={14} /> : (index + 1)}
+              </span>
+              <span className="header-step-label">{step.label}</span>
+            </div>
+          ))}
+        </div>
+      </header>
+    </>
   );
 }

--- a/src/components/shared/UpdateModal.tsx
+++ b/src/components/shared/UpdateModal.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { Download, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { getVersion } from '@tauri-apps/api/app';
+import { openUrl } from '../../hooks/useTauri';
+
+const GITHUB_API_URL = 'https://api.github.com/repos/armbian/imager/releases/latest';
+const RELEASES_URL = 'https://github.com/armbian/imager/releases/latest';
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+}
+
+function compareVersions(current: string, latest: string): number {
+  const c = current.replace(/^v/, '').split('.').map(Number);
+  const l = latest.replace(/^v/, '').split('.').map(Number);
+
+  for (let i = 0; i < Math.max(c.length, l.length); i++) {
+    const cv = c[i] || 0;
+    const lv = l[i] || 0;
+    if (cv < lv) return -1;
+    if (cv > lv) return 1;
+  }
+  return 0;
+}
+
+export function UpdateModal() {
+  const { t } = useTranslation();
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const checkForUpdate = async () => {
+      try {
+        const currentVersion = await getVersion();
+        const response = await fetch(GITHUB_API_URL);
+
+        if (!response.ok) return;
+
+        const release: GitHubRelease = await response.json();
+        const latest = release.tag_name;
+
+        if (compareVersions(currentVersion, latest) < 0) {
+          setLatestVersion(latest);
+          setUpdateAvailable(true);
+        }
+      } catch (err) {
+        console.error('Failed to check for updates:', err);
+      }
+    };
+
+    checkForUpdate();
+  }, []);
+
+  const handleDownload = () => {
+    openUrl(RELEASES_URL).catch(console.error);
+    setDismissed(true);
+  };
+
+  const handleLater = () => {
+    setDismissed(true);
+  };
+
+  if (!updateAvailable || dismissed) return null;
+
+  return (
+    <div className="update-modal-overlay">
+      <div className="update-modal">
+        <div className="update-modal-icon">
+          <RefreshCw size={32} />
+        </div>
+        <h2 className="update-modal-title">{t('update.title')}</h2>
+        <p className="update-modal-message">
+          {t('update.newVersionAvailable', { version: latestVersion })}
+        </p>
+        <div className="update-modal-buttons">
+          <button className="update-modal-btn secondary" onClick={handleLater}>
+            {t('update.later')}
+          </button>
+          <button className="update-modal-btn primary" onClick={handleDownload}>
+            <Download size={16} />
+            {t('update.download')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Unbekannt"
+  },
+  "update": {
+    "title": "Update verfügbar",
+    "newVersionAvailable": "Neue Version {{version}} verfügbar",
+    "download": "Herunterladen",
+    "later": "Später"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Unknown"
+  },
+  "update": {
+    "title": "Update Available",
+    "newVersionAvailable": "New version {{version}} available",
+    "download": "Download",
+    "later": "Later"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Desconocido"
+  },
+  "update": {
+    "title": "Actualización disponible",
+    "newVersionAvailable": "Nueva versión {{version}} disponible",
+    "download": "Descargar",
+    "later": "Más tarde"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Inconnu"
+  },
+  "update": {
+    "title": "Mise à jour disponible",
+    "newVersionAvailable": "Nouvelle version {{version}} disponible",
+    "download": "Télécharger",
+    "later": "Plus tard"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Sconosciuto"
+  },
+  "update": {
+    "title": "Aggiornamento Disponibile",
+    "newVersionAvailable": "Nuova versione {{version}} disponibile",
+    "download": "Scarica",
+    "later": "Più tardi"
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "不明"
+  },
+  "update": {
+    "title": "アップデートが利用可能",
+    "newVersionAvailable": "新しいバージョン {{version}} が利用可能です",
+    "download": "ダウンロード",
+    "later": "後で"
   }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "알 수 없음"
+  },
+  "update": {
+    "title": "업데이트 가능",
+    "newVersionAvailable": "새 버전 {{version}} 사용 가능",
+    "download": "다운로드",
+    "later": "나중에"
   }
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Onbekend"
+  },
+  "update": {
+    "title": "Update beschikbaar",
+    "newVersionAvailable": "Nieuwe versie {{version}} beschikbaar",
+    "download": "Downloaden",
+    "later": "Later"
   }
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Nieznany"
+  },
+  "update": {
+    "title": "Dostępna aktualizacja",
+    "newVersionAvailable": "Dostępna nowa wersja {{version}}",
+    "download": "Pobierz",
+    "later": "Później"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Desconhecido"
+  },
+  "update": {
+    "title": "Atualização disponível",
+    "newVersionAvailable": "Nova versão {{version}} disponível",
+    "download": "Baixar",
+    "later": "Mais tarde"
   }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Неизвестно"
+  },
+  "update": {
+    "title": "Доступно обновление",
+    "newVersionAvailable": "Доступна новая версия {{version}}",
+    "download": "Скачать",
+    "later": "Позже"
   }
 }

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Neznano"
+  },
+  "update": {
+    "title": "Na voljo posodobitev",
+    "newVersionAvailable": "Na voljo nova različica {{version}}",
+    "download": "Prenesi",
+    "later": "Kasneje"
   }
 }

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Bilinmeyen"
+  },
+  "update": {
+    "title": "Güncelleme mevcut",
+    "newVersionAvailable": "Yeni sürüm {{version}} mevcut",
+    "download": "İndir",
+    "later": "Daha sonra"
   }
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "Невідомо"
+  },
+  "update": {
+    "title": "Доступне оновлення",
+    "newVersionAvailable": "Доступна нова версія {{version}}",
+    "download": "Завантажити",
+    "later": "Пізніше"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -96,5 +96,11 @@
   },
   "common": {
     "unknown": "未知"
+  },
+  "update": {
+    "title": "有可用更新",
+    "newVersionAvailable": "新版本 {{version}} 可用",
+    "download": "下载",
+    "later": "稍后"
   }
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -828,3 +828,112 @@
     transform: translateX(var(--scroll-percent, -50%));
   }
 }
+
+/* ========================================
+   UPDATE MODAL
+   ======================================== */
+.update-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.update-modal {
+  background: var(--bg-modal);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.update-modal-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 16px;
+  background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
+  border-radius: 50%;
+  color: white;
+}
+
+.update-modal-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.update-modal-message {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 0 0 24px;
+}
+
+.update-modal-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.update-modal-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.update-modal-btn.primary {
+  background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
+  color: white;
+}
+
+.update-modal-btn.primary:hover {
+  filter: brightness(1.1);
+}
+
+.update-modal-btn.secondary {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-light);
+}
+
+.update-modal-btn.secondary:hover {
+  background: var(--bg-hover);
+}


### PR DESCRIPTION
## Summary

This PR adds an update check feature that notifies users when a new version of Armbian Imager is available.

### Changes

- **New UpdateModal component** (`src/components/shared/UpdateModal.tsx`)
  - Queries GitHub Releases API on startup to check for newer versions
  - Compares semantic versions to determine if update is needed
  - Displays a centered modal dialog when update is available
  - "Download" button opens the GitHub releases page
  - "Later" button dismisses the modal until next app launch

- **UI Integration**
  - Modal integrated into Header component
  - Styled for both light and dark themes
  - Smooth fade-in and slide-up animations

- **Internationalization**
  - Added `update.title`, `update.newVersionAvailable`, `update.download`, and `update.later` translations
  - Full support for all 15 languages (EN, IT, DE, FR, ES, PT, RU, ZH, JA, KO, NL, PL, TR, UK, SL)

### Screenshots

<img width="1212" height="813" alt="image" src="https://github.com/user-attachments/assets/1adf781f-6192-4f10-a126-395a5dad95c0" />

