### PR TITLE
Add MOTD tip banner with rotating messages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import armbianLogo from '../assets/armbian-logo.png';
 import type { BoardInfo, ImageInfo, BlockDevice } from '../types';
 import type { Manufacturer } from './ManufacturerModal';
 import { UpdateModal } from './shared/UpdateModal';
+import { MotdTip } from './shared/MotdTip';
 
 interface HeaderProps {
   selectedManufacturer?: Manufacturer | null;
@@ -52,6 +53,7 @@ export function Header({
           ))}
         </div>
       </header>
+      <MotdTip />
     </>
   );
 }

--- a/src/components/shared/MotdTip.tsx
+++ b/src/components/shared/MotdTip.tsx
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Lightbulb, ExternalLink } from 'lucide-react';
+import { openUrl } from '../../hooks/useTauri';
+
+// Configuration
+const MOTD_URL = 'https://raw.githubusercontent.com/armbian/os/main/motd.json';
+const ROTATE_INTERVAL_MS = 30000; // 30 seconds
+
+interface MotdMessage {
+  message: string;
+  url: string;
+  expiration: string;
+}
+
+export function MotdTip() {
+  const [tip, setTip] = useState<MotdMessage | null>(null);
+  const messagesRef = useRef<MotdMessage[]>([]);
+  const currentIndexRef = useRef(0);
+
+  const pickNextMessage = useCallback(() => {
+    if (messagesRef.current.length === 0) return;
+
+    // Move to next message (cycling through)
+    currentIndexRef.current = (currentIndexRef.current + 1) % messagesRef.current.length;
+    setTip(messagesRef.current[currentIndexRef.current]);
+  }, []);
+
+  useEffect(() => {
+    const fetchMotd = async () => {
+      try {
+        const response = await fetch(MOTD_URL);
+        const messages: MotdMessage[] = await response.json();
+
+        // Filter out expired messages
+        const now = new Date();
+        const validMessages = messages.filter((msg) => {
+          try {
+            // Parse date (format: YYYY-DD-MM or YYYY-MM-DD)
+            const parts = msg.expiration.split('-');
+            if (parts.length === 3) {
+              const year = parseInt(parts[0], 10);
+              const month = parseInt(parts[1], 10) - 1;
+              const day = parseInt(parts[2], 10);
+              const expDate = new Date(year, month, day);
+              return expDate > now;
+            }
+          } catch {
+            return true; // Include if date parsing fails
+          }
+          return true;
+        });
+
+        if (validMessages.length > 0) {
+          messagesRef.current = validMessages;
+          // Pick a random starting message
+          currentIndexRef.current = Math.floor(Math.random() * validMessages.length);
+          setTip(validMessages[currentIndexRef.current]);
+        }
+      } catch (err) {
+        console.error('Failed to fetch MOTD:', err);
+      }
+    };
+
+    fetchMotd();
+
+    // Rotate messages every 30 seconds
+    const interval = setInterval(pickNextMessage, ROTATE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [pickNextMessage]);
+
+  if (!tip) return null;
+
+  const handleClick = () => {
+    openUrl(tip.url).catch(console.error);
+  };
+
+  return (
+    <button className="motd-tip" onClick={handleClick}>
+      <Lightbulb size={16} className="motd-icon" />
+      <span className="motd-message">{tip.message}</span>
+      <ExternalLink size={14} className="motd-arrow" />
+    </button>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -937,3 +937,55 @@
 .update-modal-btn.secondary:hover {
   background: var(--bg-hover);
 }
+
+/* ========================================
+   MOTD TIP (Banner under header)
+   ======================================== */
+.motd-tip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 16px;
+  background: var(--bg-secondary);
+  border: none;
+  border-bottom: 1px solid var(--border-light);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.motd-tip:hover {
+  background: var(--bg-hover);
+}
+
+.motd-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  transition: color 0.2s ease;
+}
+
+.motd-tip:hover .motd-icon {
+  color: var(--accent);
+}
+
+.motd-message {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.motd-tip:hover .motd-message {
+  color: var(--text-primary);
+}
+
+.motd-arrow {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.motd-tip:hover .motd-arrow {
+  opacity: 1;
+  color: var(--accent);
+}


### PR DESCRIPTION
## Summary

Adds a MOTD (Message of the Day) tip banner that displays below the header with rotating helpful tips for users.

Closes #11

### Changes

- **New MotdTip component** (`src/components/shared/MotdTip.tsx`)
  - Displays rotating tips/hints below the header
  - Clickable banner with hover effects
  - Uses Lightbulb icon for visual appeal

- **UI Integration**
  - Banner positioned between header and main content
  - Styled for both light and dark themes
  - Smooth hover transitions

- **CSS Styles**
  - Added `.motd-tip` styles with icon, message, and arrow elements
  - Responsive hover states with accent color highlights

### Screenshots

<img width="1212" height="813" alt="image" src="https://github.com/user-attachments/assets/68df2ca5-e787-46f2-a33b-0d99a5746450" />
