### PR TITLE
Add device disconnect detection, decompression formats, and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/armbian/imager/releases"><img src="https://img.shields.io/github/v/release/armbian/imager?style=for-the-badge&color=orange" alt="Release"></a>
+  <a href="https://github.com/armbian/imager/releases"><img src="https://img.shields.io/github/downloads/armbian/imager/total?style=for-the-badge&color=green" alt="Downloads"></a>
   <a href="https://github.com/armbian/imager/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-GPLv2-blue?style=for-the-badge" alt="License"></a>
 </p>
 
@@ -42,12 +43,10 @@
 
 macOS may show a warning because the app is not signed with an Apple Developer certificate. To open it:
 
-**Option 1:** Right-click the app → **Open** → Click **Open** in the dialog
-
-**Option 2:** Run in Terminal:
-```bash
-xattr -cr "/Applications/Armbian Imager.app"
-```
+1. Try to open the app (it will be blocked)
+2. Go to **System Settings** → **Privacy & Security**
+3. Scroll down and click **Open Anyway** next to "Armbian Imager was blocked"
+4. Click **Open** in the confirmation dialog
 
 This only needs to be done once.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 futures-util = "0.3"
 liblzma = { version = "0.4", features = ["static"] }
+flate2 = "1.0"
+bzip2 = "0.4"
+zstd = "0.13"
 sha2 = "0.10"
 hex = "0.4"
 dirs = "5"

--- a/src-tauri/src/commands/custom_image.rs
+++ b/src-tauri/src/commands/custom_image.rs
@@ -76,7 +76,7 @@ pub async fn select_custom_image(
         .file()
         .add_filter(
             "Disk Images",
-            &["img", "iso", "xz", "gz", "zip", "zst", "bz2", "raw"],
+            &["img", "iso", "raw", "xz", "gz", "bz2", "zst"],
         )
         .add_filter("All Files", &["*"])
         .set_title("Select Disk Image")

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -7,6 +7,12 @@ use sys_locale::get_locale;
 
 const MODULE: &str = "commands::system";
 
+/// Log a message from the frontend
+#[tauri::command]
+pub fn log_from_frontend(module: String, message: String) {
+    log_info!(&format!("frontend::{}", module), "{}", message);
+}
+
 /// Get the system locale (e.g., "en-US", "it-IT", "de-DE")
 /// Returns the language code for i18n initialization
 #[tauri::command]

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::config;
-use crate::decompress::{decompress_with_rust_library, decompress_with_system_xz};
+use crate::decompress::{decompress_with_rust_xz, decompress_with_system_xz};
 use crate::{log_error, log_info, log_warn};
 
 const MODULE: &str = "download";
@@ -305,7 +305,7 @@ pub async fn download_image(
                 "System xz failed: {}, falling back to Rust library (slower)",
                 e
             );
-            decompress_with_rust_library(&temp_path, &output_path, &state)?;
+            decompress_with_rust_xz(&temp_path, &output_path, &state)?;
             log_info!(MODULE, "Rust fallback decompression complete");
         }
 

--- a/src-tauri/src/flash/macos/authorization.rs
+++ b/src-tauri/src/flash/macos/authorization.rs
@@ -34,7 +34,8 @@ pub fn request_authorization(device_path: &str) -> Result<bool, String> {
 
     unsafe {
         let right_name = format!("sys.openfile.readwrite.{}", raw_device);
-        let right_name_cstr = std::ffi::CString::new(right_name.clone()).unwrap();
+        let right_name_cstr = std::ffi::CString::new(right_name.clone())
+            .map_err(|_| "Invalid device path: contains null byte".to_string())?;
 
         let mut item = AuthorizationItem {
             name: right_name_cstr.as_ptr(),

--- a/src-tauri/src/flash/macos/writer.rs
+++ b/src-tauri/src/flash/macos/writer.rs
@@ -83,12 +83,15 @@ pub fn open_device_with_saved_auth(device_path: &str) -> Result<OpenDeviceResult
             // Redirect stdin from pipe
             libc::dup2(stdin_pipe[0], libc::STDIN_FILENO);
 
-            let authopen = std::ffi::CString::new("/usr/libexec/authopen").unwrap();
-            let arg_stdoutpipe = std::ffi::CString::new("-stdoutpipe").unwrap();
-            let arg_extauth = std::ffi::CString::new("-extauth").unwrap();
-            let arg_o = std::ffi::CString::new("-o").unwrap();
-            let arg_mode = std::ffi::CString::new("2").unwrap(); // O_RDWR
-            let path = std::ffi::CString::new(device_path).unwrap();
+            let authopen = std::ffi::CString::new("/usr/libexec/authopen").expect("static string");
+            let arg_stdoutpipe = std::ffi::CString::new("-stdoutpipe").expect("static string");
+            let arg_extauth = std::ffi::CString::new("-extauth").expect("static string");
+            let arg_o = std::ffi::CString::new("-o").expect("static string");
+            let arg_mode = std::ffi::CString::new("2").expect("static string");
+            let path = match std::ffi::CString::new(device_path) {
+                Ok(p) => p,
+                Err(_) => libc::_exit(2),
+            };
 
             libc::execl(
                 authopen.as_ptr(),

--- a/src-tauri/src/flash/mod.rs
+++ b/src-tauri/src/flash/mod.rs
@@ -14,10 +14,6 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 
-use sha2::{Digest, Sha256};
-use std::fs::File;
-use std::io::Read;
-use std::path::PathBuf;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -117,27 +113,4 @@ pub(crate) fn sync_device(_device_path: &str) {
     {
         let _ = Command::new("sync").output();
     }
-}
-
-/// Calculate SHA256 hash of a file
-#[allow(dead_code)]
-pub fn calculate_sha256(path: &PathBuf) -> Result<String, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-
-    let mut hasher = Sha256::new();
-    let mut buffer = vec![0u8; 1024 * 1024];
-
-    loop {
-        let bytes_read = file
-            .read(&mut buffer)
-            .map_err(|e| format!("Failed to read file: {}", e))?;
-
-        if bytes_read == 0 {
-            break;
-        }
-
-        hasher.update(&buffer[..bytes_read]);
-    }
-
-    Ok(hex::encode(hasher.finalize()))
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
             commands::custom_image::decompress_custom_image,
             commands::system::open_url,
             commands::system::get_system_locale,
+            commands::system::log_from_frontend,
             paste::upload::upload_logs,
         ])
         .setup(|app| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,8 @@ import { FlashProgress } from './components/FlashProgress';
 import { AppVersion } from './components/shared/AppVersion';
 import { selectCustomImage } from './hooks/useTauri';
 import { useDeviceMonitor } from './hooks/useDeviceMonitor';
-import type { BoardInfo, ImageInfo, BlockDevice, ModalType } from './types';
+import type { BoardInfo, ImageInfo, BlockDevice, ModalType, SelectionStep } from './types';
 import './styles/index.css';
-
-/** Selection step in the wizard flow */
-type SelectionStep = 'manufacturer' | 'board' | 'image' | 'device';
 
 function App() {
   const { t } = useTranslation();

--- a/src/components/BoardModal.tsx
+++ b/src/components/BoardModal.tsx
@@ -30,11 +30,13 @@ export function BoardModal({ isOpen, onClose, onSelect, manufacturer }: BoardMod
     [isOpen]
   );
 
+  // Reset state when modal closes or manufacturer changes
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Reset state when manufacturer changes
+    if (!isOpen) {
+      setImagesReady(false);
+    }
     setSearch('');
-    setImagesReady(false);
-  }, [manufacturer]);
+  }, [isOpen, manufacturer]);
 
   // Pre-load images for current manufacturer
   useEffect(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,10 @@
 import { Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import armbianLogo from '../assets/armbian-logo.png';
-import type { BoardInfo, ImageInfo, BlockDevice } from '../types';
+import type { BoardInfo, ImageInfo, BlockDevice, SelectionStep } from '../types';
 import type { Manufacturer } from './ManufacturerModal';
 import { UpdateModal } from './shared/UpdateModal';
 import { MotdTip } from './shared/MotdTip';
-
-type NavigationStep = 'manufacturer' | 'board' | 'image' | 'device';
 
 interface HeaderProps {
   selectedManufacturer?: Manufacturer | null;
@@ -14,7 +12,7 @@ interface HeaderProps {
   selectedImage?: ImageInfo | null;
   selectedDevice?: BlockDevice | null;
   onReset?: () => void;
-  onNavigateToStep?: (step: NavigationStep) => void;
+  onNavigateToStep?: (step: SelectionStep) => void;
   isFlashing?: boolean;
 }
 
@@ -33,14 +31,14 @@ export function Header({
   // For custom images, show different steps
   const steps = isCustomImage
     ? [
-        { key: 'image' as NavigationStep, label: t('header.stepImage'), completed: !!selectedImage },
-        { key: 'device' as NavigationStep, label: t('header.stepStorage'), completed: !!selectedDevice },
+        { key: 'image' as SelectionStep, label: t('header.stepImage'), completed: !!selectedImage },
+        { key: 'device' as SelectionStep, label: t('header.stepStorage'), completed: !!selectedDevice },
       ]
     : [
-        { key: 'manufacturer' as NavigationStep, label: t('header.stepManufacturer'), completed: !!selectedManufacturer },
-        { key: 'board' as NavigationStep, label: t('header.stepBoard'), completed: !!selectedBoard },
-        { key: 'image' as NavigationStep, label: t('header.stepOs'), completed: !!selectedImage },
-        { key: 'device' as NavigationStep, label: t('header.stepStorage'), completed: !!selectedDevice },
+        { key: 'manufacturer' as SelectionStep, label: t('header.stepManufacturer'), completed: !!selectedManufacturer },
+        { key: 'board' as SelectionStep, label: t('header.stepBoard'), completed: !!selectedBoard },
+        { key: 'image' as SelectionStep, label: t('header.stepOs'), completed: !!selectedImage },
+        { key: 'device' as SelectionStep, label: t('header.stepStorage'), completed: !!selectedDevice },
       ];
 
   function handleLogoClick() {
@@ -49,7 +47,7 @@ export function Header({
     }
   }
 
-  function handleStepClick(step: NavigationStep, completed: boolean) {
+  function handleStepClick(step: SelectionStep, completed: boolean) {
     // Only allow clicking on completed steps, and not during flashing
     if (!isFlashing && completed && onNavigateToStep) {
       onNavigateToStep(step);

--- a/src/components/ManufacturerModal.tsx
+++ b/src/components/ManufacturerModal.tsx
@@ -92,8 +92,16 @@ export function ManufacturerModal({ isOpen, onClose, onSelect }: ManufacturerMod
 
   // Preload all vendor logos
   const [logosLoaded, setLogosLoaded] = useState(false);
+
+  // Reset logos loaded state when modal closes
   useEffect(() => {
-    if (!manufacturers.length || logosLoaded) return;
+    if (!isOpen) {
+      setLogosLoaded(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !manufacturers.length || logosLoaded) return;
 
     const vendorsWithLogos = manufacturers.filter(m => vendorHasLogo(m.id) && m.id !== 'other');
     if (vendorsWithLogos.length === 0) {
@@ -112,7 +120,7 @@ export function ManufacturerModal({ isOpen, onClose, onSelect }: ManufacturerMod
       };
       img.src = getVendorLogoUrl(m.id);
     });
-  }, [manufacturers, logosLoaded]);
+  }, [isOpen, manufacturers, logosLoaded]);
 
   const searchBarContent = (
     <div className="modal-search">

--- a/src/components/shared/MarqueeText.tsx
+++ b/src/components/shared/MarqueeText.tsx
@@ -30,9 +30,16 @@ export function MarqueeText({ text, maxWidth = 180, className = '' }: MarqueeTex
         text-transform: ${computedStyle.textTransform};
       `;
       measureSpan.textContent = text;
-      document.body.appendChild(measureSpan);
-      const singleTextWidth = measureSpan.offsetWidth;
-      document.body.removeChild(measureSpan);
+
+      let singleTextWidth = 0;
+      try {
+        document.body.appendChild(measureSpan);
+        singleTextWidth = measureSpan.offsetWidth;
+      } finally {
+        if (measureSpan.parentNode) {
+          measureSpan.parentNode.removeChild(measureSpan);
+        }
+      }
 
       const overflow = singleTextWidth > maxWidth;
       setIsOverflow(overflow);

--- a/src/components/shared/MotdTip.tsx
+++ b/src/components/shared/MotdTip.tsx
@@ -34,20 +34,9 @@ export function MotdTip() {
         // Filter out expired messages
         const now = new Date();
         const validMessages = messages.filter((msg) => {
-          try {
-            // Parse date (format: YYYY-DD-MM or YYYY-MM-DD)
-            const parts = msg.expiration.split('-');
-            if (parts.length === 3) {
-              const year = parseInt(parts[0], 10);
-              const month = parseInt(parts[1], 10) - 1;
-              const day = parseInt(parts[2], 10);
-              const expDate = new Date(year, month, day);
-              return expDate > now;
-            }
-          } catch {
-            return true; // Include if date parsing fails
-          }
-          return true;
+          if (!msg.expiration) return true;
+          const expDate = new Date(msg.expiration);
+          return isNaN(expDate.getTime()) || expDate > now;
         });
 
         if (validMessages.length > 0) {

--- a/src/components/shared/UpdateModal.tsx
+++ b/src/components/shared/UpdateModal.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Download, RefreshCw, CheckCircle, AlertCircle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { check, Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { logInfo } from '../../hooks/useTauri';
 
 type UpdateState = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error';
 
@@ -18,8 +19,12 @@ export function UpdateModal() {
   const [progress, setProgress] = useState<DownloadProgress>({ downloaded: 0, total: null });
   const [error, setError] = useState<string | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const hasCheckedRef = useRef(false);
 
   const checkForUpdate = useCallback(async () => {
+    if (hasCheckedRef.current) return;
+    hasCheckedRef.current = true;
+
     setState('checking');
     setError(null);
 
@@ -29,7 +34,9 @@ export function UpdateModal() {
       if (updateResult) {
         setUpdate(updateResult);
         setState('available');
+        logInfo('updater', `Update available: ${updateResult.currentVersion} -> ${updateResult.version}`);
       } else {
+        logInfo('updater', 'No updates available');
         setState('idle');
       }
     } catch (err) {

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -88,3 +88,7 @@ export async function uploadLogs(): Promise<UploadResult> {
 export async function openUrl(url: string): Promise<void> {
   return invoke('open_url', { url });
 }
+
+export async function logInfo(module: string, message: string): Promise<void> {
+  return invoke('log_from_frontend', { module, message });
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -91,7 +91,8 @@
     "authFailed": "Autorisierung fehlgeschlagen",
     "authCancelled": "Autorisierung vom Benutzer abgebrochen",
     "decompressionFailed": "Dekomprimierung fehlgeschlagen",
-    "uploadFailed": "Hochladen fehlgeschlagen"
+    "uploadFailed": "Hochladen fehlgeschlagen",
+    "deviceDisconnected": "Gerät wurde getrennt"
   },
   "custom": {
     "customImage": "Benutzerdefiniertes Image"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,7 +91,8 @@
     "authFailed": "Authorization failed",
     "authCancelled": "Authorization cancelled by user",
     "decompressionFailed": "Decompression failed",
-    "uploadFailed": "Upload failed"
+    "uploadFailed": "Upload failed",
+    "deviceDisconnected": "Device was disconnected"
   },
   "custom": {
     "customImage": "Custom Image"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -91,7 +91,8 @@
     "authFailed": "Error de autorización",
     "authCancelled": "Autorización cancelada por el usuario",
     "decompressionFailed": "Error de descompresión",
-    "uploadFailed": "Error al subir"
+    "uploadFailed": "Error al subir",
+    "deviceDisconnected": "El dispositivo fue desconectado"
   },
   "custom": {
     "customImage": "Imagen personalizada"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -91,7 +91,8 @@
     "authFailed": "Échec de l'autorisation",
     "authCancelled": "Autorisation annulée par l'utilisateur",
     "decompressionFailed": "Échec de la décompression",
-    "uploadFailed": "Échec du téléversement"
+    "uploadFailed": "Échec du téléversement",
+    "deviceDisconnected": "L'appareil a été déconnecté"
   },
   "custom": {
     "customImage": "Image personnalisée"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -91,7 +91,8 @@
     "authFailed": "Autorizzazione fallita",
     "authCancelled": "Autorizzazione annullata dall'utente",
     "decompressionFailed": "Decompressione fallita",
-    "uploadFailed": "Caricamento fallito"
+    "uploadFailed": "Caricamento fallito",
+    "deviceDisconnected": "Dispositivo disconnesso"
   },
   "custom": {
     "customImage": "Immagine Personalizzata"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -91,7 +91,8 @@
     "authFailed": "認証失敗",
     "authCancelled": "ユーザーにより認証がキャンセルされました",
     "decompressionFailed": "解凍失敗",
-    "uploadFailed": "アップロード失敗"
+    "uploadFailed": "アップロード失敗",
+    "deviceDisconnected": "デバイスが切断されました"
   },
   "custom": {
     "customImage": "カスタムイメージ"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -91,7 +91,8 @@
     "authFailed": "인증 실패",
     "authCancelled": "사용자가 인증을 취소했습니다",
     "decompressionFailed": "압축 해제 실패",
-    "uploadFailed": "업로드 실패"
+    "uploadFailed": "업로드 실패",
+    "deviceDisconnected": "장치 연결이 해제되었습니다"
   },
   "custom": {
     "customImage": "사용자 정의 이미지"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -91,7 +91,8 @@
     "authFailed": "Autorisatie mislukt",
     "authCancelled": "Autorisatie geannuleerd door gebruiker",
     "decompressionFailed": "Uitpakken mislukt",
-    "uploadFailed": "Upload mislukt"
+    "uploadFailed": "Upload mislukt",
+    "deviceDisconnected": "Apparaat is losgekoppeld"
   },
   "custom": {
     "customImage": "Aangepaste image"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -91,7 +91,8 @@
     "authFailed": "Autoryzacja nie powiodła się",
     "authCancelled": "Autoryzacja anulowana przez użytkownika",
     "decompressionFailed": "Rozpakowywanie nie powiodło się",
-    "uploadFailed": "Przesyłanie nie powiodło się"
+    "uploadFailed": "Przesyłanie nie powiodło się",
+    "deviceDisconnected": "Urządzenie zostało odłączone"
   },
   "custom": {
     "customImage": "Własny obraz"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -91,7 +91,8 @@
     "authFailed": "Falha na autorização",
     "authCancelled": "Autorização cancelada pelo usuário",
     "decompressionFailed": "Falha na descompactação",
-    "uploadFailed": "Falha no envio"
+    "uploadFailed": "Falha no envio",
+    "deviceDisconnected": "Dispositivo foi desconectado"
   },
   "custom": {
     "customImage": "Imagem personalizada"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -91,7 +91,8 @@
     "authFailed": "Ошибка авторизации",
     "authCancelled": "Авторизация отменена пользователем",
     "decompressionFailed": "Ошибка распаковки",
-    "uploadFailed": "Ошибка загрузки"
+    "uploadFailed": "Ошибка загрузки",
+    "deviceDisconnected": "Устройство было отключено"
   },
   "custom": {
     "customImage": "Свой образ"

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -91,7 +91,8 @@
     "authFailed": "Avtorizacija ni uspela",
     "authCancelled": "Uporabnik je preklical avtorizacijo",
     "decompressionFailed": "Razširjanje ni uspelo",
-    "uploadFailed": "Nalaganje ni uspelo"
+    "uploadFailed": "Nalaganje ni uspelo",
+    "deviceDisconnected": "Naprava je bila odklopljena"
   },
   "custom": {
     "customImage": "Slika po meri"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -91,7 +91,8 @@
     "authFailed": "Yetkilendirme başarısız",
     "authCancelled": "Yetkilendirme kullanıcı tarafından iptal edildi",
     "decompressionFailed": "Açma başarısız",
-    "uploadFailed": "Yükleme başarısız"
+    "uploadFailed": "Yükleme başarısız",
+    "deviceDisconnected": "Cihaz bağlantısı kesildi"
   },
   "custom": {
     "customImage": "Özel İmaj"

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -91,7 +91,8 @@
     "authFailed": "Помилка авторизації",
     "authCancelled": "Авторизацію скасовано користувачем",
     "decompressionFailed": "Помилка розпакування",
-    "uploadFailed": "Помилка завантаження"
+    "uploadFailed": "Помилка завантаження",
+    "deviceDisconnected": "Пристрій було від'єднано"
   },
   "custom": {
     "customImage": "Власний образ"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -91,7 +91,8 @@
     "authFailed": "授权失败",
     "authCancelled": "用户取消了授权",
     "decompressionFailed": "解压失败",
-    "uploadFailed": "上传失败"
+    "uploadFailed": "上传失败",
+    "deviceDisconnected": "设备已断开连接"
   },
   "custom": {
     "customImage": "自定义镜像"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -6,6 +6,8 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 html, body, #root {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -917,6 +917,8 @@
   cursor: pointer;
   transition: all 0.2s ease;
   border: none;
+  flex: 1;
+  max-width: 160px;
 }
 
 .update-modal-btn.primary {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,9 +66,14 @@ export interface Manufacturer {
 export type ImageFilterType = 'all' | 'recommended' | 'stable' | 'nightly' | 'apps' | 'barebone';
 
 /**
- * Modal type for app navigation
+ * Selection step in the wizard flow
  */
-export type ModalType = 'none' | 'manufacturer' | 'board' | 'image' | 'device';
+export type SelectionStep = 'manufacturer' | 'board' | 'image' | 'device';
+
+/**
+ * Modal type for app navigation (includes 'none' for closed state)
+ */
+export type ModalType = 'none' | SelectionStep;
 
 /**
  * Custom image info from file picker


### PR DESCRIPTION
- Monitor device connection during all flash stages (download, SHA verify, decompress, write, verify)
- Show "Device was disconnected" error instead of generic errors when device is removed
- Re-request authorization on retry after disconnect
- Add GZ, BZ2, ZSTD decompression support alongside XZ
- Log update availability at startup via frontend logging
- Fix Update Modal button sizing (equal width)
- Disable text selection globally in production
- Update README: download badge, macOS Privacy & Security instructions
- Add deviceDisconnected translation to all 15 languages
- Various code quality improvements (unwrap → expect, try/finally cleanup)