### PR TITLE
chore: skip PR checks for documentation and non-code files

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,23 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".env*"
+      - ".github/**"
+      - "images/**"
+      - "scripts/**"
+      - "releases/**"
+      - "build/**"
+      - "dist/**"
+      - "*.png"
+      - "*.jpg"
+      - "*.jpeg"
+      - "*.gif"
+      - "*.svg"
+      - "*.ico"
 
 # Cancel in-progress runs for the same PR
 concurrency:


### PR DESCRIPTION
Add paths-ignore filter to pr-check workflow to skip running lint, type check, and build jobs when only documentation, images, or configuration files are modified.