### PR TITLE
feat: replace liblzma with lzma-rust2 for multi-threaded XZ decompression

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,9 +20,10 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 futures-util = "0.3"
-liblzma = { version = "0.4", features = ["static"] }
-flate2 = "1.0"
+# Multi-threaded decompression libraries
+lzma-rust2 = { version = "0.15", features = ["xz", "std"] }
 bzip2 = "0.4"
+flate2 = "1.0"
 zstd = "0.13"
 sha2 = "0.10"
 hex = "0.4"

--- a/src-tauri/src/utils/system.rs
+++ b/src-tauri/src/utils/system.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 /// Get the number of CPU cores available on the system
-fn get_cpu_cores() -> usize {
+pub fn get_cpu_cores() -> usize {
     std::thread::available_parallelism()
         .map(|p| p.get())
         .unwrap_or(2)
@@ -15,49 +15,6 @@ fn get_cpu_cores() -> usize {
 /// Uses half of available cores to avoid saturating the system
 pub fn get_recommended_threads() -> usize {
     std::cmp::max(1, get_cpu_cores() / 2)
-}
-
-/// Find a binary in common system locations
-/// Returns the first path that exists
-pub fn find_binary(name: &str) -> Option<PathBuf> {
-    let paths = get_binary_search_paths(name);
-
-    paths.into_iter().find(|path| path.exists())
-}
-
-/// Get platform-specific search paths for a binary
-fn get_binary_search_paths(name: &str) -> Vec<PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        vec![
-            PathBuf::from(format!("/opt/homebrew/bin/{}", name)), // macOS ARM
-            PathBuf::from(format!("/usr/local/bin/{}", name)),    // macOS Intel
-            PathBuf::from(format!("/usr/bin/{}", name)),
-        ]
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        vec![
-            PathBuf::from(format!("/usr/bin/{}", name)),
-            PathBuf::from(format!("/bin/{}", name)),
-            PathBuf::from(format!("/usr/local/bin/{}", name)),
-        ]
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        // On Windows, rely on PATH or specific install locations
-        vec![
-            PathBuf::from(format!("C:\\Program Files\\{0}\\{0}.exe", name)),
-            PathBuf::from(format!("C:\\Program Files (x86)\\{0}\\{0}.exe", name)),
-        ]
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        vec![PathBuf::from(format!("/usr/bin/{}", name))]
-    }
 }
 
 /// Get the cache directory for the application


### PR DESCRIPTION
- Replace liblzma C bindings with native Rust lzma-rust2 library
- Use XzReaderMt for parallel decompression across all platforms
- Remove dependency on system xz command
- Use get_recommended_threads() to utilize half of CPU cores
- Clean up unused find_binary and get_binary_search_paths functions
- Update module documentation to reflect native Rust approach

This change provides consistent multi-threaded decompression performance across macOS, Linux, and Windows without requiring external tools.