### PR TITLE
feat: detect board from custom image filename and improve decompression

### DIFF
--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -61,6 +61,21 @@ export async function deleteDownloadedImage(imagePath: string): Promise<void> {
   return invoke('delete_downloaded_image', { imagePath });
 }
 
+export async function deleteDecompressedCustomImage(imagePath: string): Promise<void> {
+  return invoke('delete_decompressed_custom_image', { imagePath });
+}
+
+/**
+ * Detects board information from custom image filename
+ * Parses Armbian naming convention to extract board slug and match against database
+ *
+ * @param filename - Filename (can include path)
+ * @returns Promise resolving to BoardInfo if detected, null otherwise
+ */
+export async function detectBoardFromFilename(filename: string): Promise<BoardInfo | null> {
+  return invoke('detect_board_from_filename', { filename });
+}
+
 // Re-export CustomImageInfo for backward compatibility
 export type { CustomImageInfo } from '../types';
 


### PR DESCRIPTION
Board detection:
- Parse Armbian filename pattern (Armbian_VERSION_BOARD_DISTRO_...) to extract board name
- Match extracted board name against database to show board image instead of generic icon
- Auto-load board data if not cached with race condition protection
- Fallback to generic icon for non-Armbian images

Decompression improvements:
- Decompress custom images to app cache directory (custom-decompress/)
- Use timestamp-based unique filenames to avoid conflicts
- Cleanup decompressed files after successful flash

Performance:
- Optimize lock scope to release mutex early after extracting boards
- Use compare-and-swap pattern to prevent race conditions