### PR TITLE
Add Docker-based ARM64 runner for Armbian Imager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /opt/armbian-imager
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    wget \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libxcb1 \
+    libx11-6 \
+    libxrender1 \
+    libxext6 \
+    libxi6 \
+    libxrandr2 \
+    libxinerama1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxfixes3 \
+    libdrm2 \
+    libgbm1 \
+    udev \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION=1.2.3
+
+RUN wget https://github.com/armbian/imager/releases/download/v${VERSION}/Armbian.Imager_${VERSION}_arm64.deb \
+ && apt-get update \
+ && apt-get install -y ./Armbian.Imager_${VERSION}_arm64.deb \
+ && rm Armbian.Imager_${VERSION}_arm64.deb
+
+VOLUME ["/dev", "/run/udev"]
+
+ENTRYPOINT ["armbian-imager"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+# Armbian Imager – Docker (ARM64)
+
+This directory provides a Docker-based method for running Armbian Imager
+on ARM64 systems where host GLIBC versions are too old to run the prebuilt binary.
+
+This is intended as a **community-supported workaround** and does not replace
+native packages.
+
+## Use cases
+- Older Armbian / Debian / Ubuntu releases
+- GLIBC version mismatch errors
+- Clean, reproducible runtime environment
+
+## Requirements
+- ARM64 host
+- Docker
+- X11 display server
+- Privileged container access (for block device flashing)
+
+## Build
+```bash
+docker build -t armbian-imager-docker docker/

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+xhost +local:docker >/dev/null
+
+docker run --rm -it \
+  --privileged \
+  --network host \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v /dev:/dev \
+  -v /run/udev:/run/udev \
+  armbian-imager-docker
+
+xhost -local:docker >/dev/null


### PR DESCRIPTION
Add Docker-based ARM64 runner for Armbian Imager

This PR adds an optional Docker-based method for running Armbian Imager on ARM64 systems.

It addresses GLIBC version mismatch issues on older distributions by running the official
ARM64 .deb inside a modern userspace (Ubuntu 24.04).

The Docker setup is:

Fully optional and isolated under docker/

Based on official Armbian release artifacts

Intended as a community-supported workaround

Does not alter existing release or packaging workflows

This should help users on older Armbian, Debian, or Ubuntu systems run the GUI imager
without upgrading their host OS.