### PR TITLE
gha: build: linux: use `debian:oldstable` to build linux amd64/arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
     needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_linux_x64 }}
     runs-on: ubuntu-24.04
+    container: { image: "debian:oldstable" }
     permissions:
       contents: write
     steps:
@@ -127,8 +128,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          apt-get update
+          apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
@@ -195,6 +196,7 @@ jobs:
     needs: [create-release]
     if: ${{ github.event_name == 'push' || inputs.build_linux_arm64 }}
     runs-on: ubuntu-24.04-arm
+    container: { image: "debian:oldstable" }
     permissions:
       contents: write
     steps:
@@ -224,8 +226,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          apt-get update
+          apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \


### PR DESCRIPTION
### gha: build: linux: use `debian:oldstable` to build linux amd64/arm64

- this should reduce the glibc dep version requirement with no side effects
- drop 'sudo' from apt calls

- ~~I've not fully tested as build seems to require secrets, but it's promising: see https://github.com/rpardini/armbian-imager/actions/runs/20647418649/job/59286872279~~ builds fine after I disabled the updated/secrets requirement https://github.com/rpardini/armbian-imager/actions/runs/20648192121/job/59288731687 