### PR TITLE
gha: build: linux: rework into matrix; use bookworm for .deb builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,10 +162,17 @@ jobs:
             xdg-utils
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          package-manager-cache: false # setup-node can't add key to cache, so we do it ourselves in below step
+
+      # Cache npm, just like setup-node would do it with "cache: npm", but with our own key that includes arch and distro
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ matrix.arch.runner }}-${{ matrix.arch.name }}-${{ matrix.type.distro_id }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -174,12 +181,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # ensure cache separation per host distro; this also ends up caching tauri-cli, so add that to key too.
+          key: "rust-cache-${{ matrix.arch.runner }}-${{ matrix.arch.name }}-${{ matrix.type.distro_id }}-${{env.TAURI_CLI_VERSION}}"
+          # @TODO: Cargo.lock is in gitignore, so it's not included here - it would via rust-cache Action magic, no need to specify it.
 
-      - name: Cache cargo bin (tauri-cli)
+      - name: Cache cargo bin (tauri-cli) # @TODO: Swatinem/rust-cache already caches this. maybe just drop this.
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-stable-${{ hashFiles('**/Cargo.lock') }}
+          key: "cargo-bin-${{ matrix.arch.runner }}-${{ matrix.arch.name }}-${{ matrix.type.distro_id }}-stable-${{env.TAURI_CLI_VERSION}}-${{ hashFiles('**/Cargo.lock') }}"
+          # @TODO: Cargo.lock is in gitignore, so it's not included here, albeit being specified.
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
#### gha: build: linux: rework into matrix; use bookworm for .deb builds

- gha: build: linux: rework into matrix; use bookworm for .deb builds
  - this should reduce the glibc dep version requirement of .deb's, allowing them to run on old but still supported systems
    - See https://v2.tauri.app/distribute/debian/#limitations
      - "you must build your Tauri application using the oldest base system you intend to support"
      - Debian oldstable (Bookworm) will be supported until late 2028, so fair to support it
      - also, there's no downsides; imager itself runs great either way, and .deb install pulls updated deps on newer distros
  - fold linux-x64 and linux-amd64 into a single matrix job (1st level)
  - 2nd matrix level is per-type:
    - `deb` is now built using an oldtable container
    - `appimage` is built without container, directly on runner, as before
       - seems like appimage/`linuxdeploy` doesn't wanna be run in a container
       - also, the AppImage does seem to contain libs, so we don't wanna ship old ones
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
- gha: build: set a specific TAURI_CLI_VERSION (`2.9.6`)
  - so we can hash it into the cache keys (done in later commit) for consistency
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
- gha: build: linux: rework caching for consistency
  - `actions/setup-node` doesn't allow for setting cache keys
    - even in recent versions... (bumped to v6)
    - so move npm caching to `actions/cache`:
      - disable `setup-node` caching via `package-manager-cache: false`
      - add new step for `actions/cache` "npm dependencies"
        - cache key includes the runner image, the container distro (if any), and hash of `package-lock.json`
  - for `Swatinem/rust-cache`
    - use a cache key that includes the runner image, the container distro (if any), and TAURI_CLI_VERSION
    - add a TODO ref Cargo.lock missing/.gitignored, as it would be hashed too automatically had it existed
  - for `actions/cache` based "cargo bin tauri-cli" caching
    - use a cache key that includes the runner image, the container distro (if any), and TAURI_CLI_VERSION
    - also TODO ref Cargo.lock, which was spelled out, but doesn't exist
    - also TODO as it seems to me this is already covered by the `Swatinem/rust-cache` cache
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>