### PR TITLE
Feature: Download only option and Trunk SHA verification fix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3319,7 +3319,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-fhyD2BLrew6qYf4NNtHff1rLXvzR25rq49p+FeqByOazc6TcSi2n8EYulo5C1PbH+1uBW++5S1SG7FcUU6mlDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/src-tauri/src/images/mod.rs
+++ b/src-tauri/src/images/mod.rs
@@ -11,7 +11,15 @@ pub use models::{BoardInfo, ImageInfo};
 // ArmbianImage is used internally by filters module
 
 use crate::config;
-use crate::{log_error, log_info};
+use crate::{log_debug, log_error, log_info, log_warn};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+/// GitHub releases API URL for Armbian OS releases
+const GITHUB_RELEASES_API: &str = "https://api.github.com/repos/armbian/os/releases/latest";
+
+/// Cached SHA256 digests from GitHub releases (filename -> sha256 hash)
+static DIGEST_CACHE: RwLock<Option<HashMap<String, String>>> = RwLock::new(None);
 
 /// Fetch the all-images.json from Armbian
 pub async fn fetch_all_images() -> Result<serde_json::Value, String> {
@@ -33,4 +41,121 @@ pub async fn fetch_all_images() -> Result<serde_json::Value, String> {
 
     log_info!("images", "Successfully fetched images data");
     Ok(json)
+}
+
+/// Fetch SHA256 digests from GitHub releases API
+/// Returns a map of filename -> sha256 hash
+pub async fn fetch_github_digests() -> Result<HashMap<String, String>, String> {
+    // Check cache first
+    {
+        let cache = DIGEST_CACHE.read().map_err(|e| format!("Cache lock error: {}", e))?;
+        if let Some(ref digests) = *cache {
+            log_debug!("images", "Using cached GitHub digests ({} entries)", digests.len());
+            return Ok(digests.clone());
+        }
+    }
+
+    log_info!("images", "Fetching GitHub release digests from {}", GITHUB_RELEASES_API);
+
+    let client = reqwest::Client::builder()
+        .user_agent(config::app::USER_AGENT)
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let response = client
+        .get(GITHUB_RELEASES_API)
+        .send()
+        .await
+        .map_err(|e| {
+            log_error!("images", "Failed to fetch GitHub releases: {}", e);
+            format!("Failed to fetch GitHub releases: {}", e)
+        })?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "GitHub API request failed with status: {}",
+            response.status()
+        ));
+    }
+
+    let release: serde_json::Value = response.json().await.map_err(|e| {
+        log_error!("images", "Failed to parse GitHub releases JSON: {}", e);
+        format!("Failed to parse GitHub releases: {}", e)
+    })?;
+
+    let mut digests = HashMap::new();
+
+    // Parse assets array
+    if let Some(assets) = release.get("assets").and_then(|a| a.as_array()) {
+        for asset in assets {
+            // Get the filename from "name" field
+            let name = match asset.get("name").and_then(|n| n.as_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+
+            // Get the digest from "digest" field (format: "sha256:...")
+            if let Some(digest) = asset.get("digest").and_then(|d| d.as_str()) {
+                // Extract just the hash part (remove "sha256:" prefix)
+                let hash = if let Some(stripped) = digest.strip_prefix("sha256:") {
+                    stripped.to_lowercase()
+                } else {
+                    // If no prefix, use the whole string
+                    digest.to_lowercase()
+                };
+
+                // Validate it looks like a SHA256 hash (64 hex chars)
+                if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+                    digests.insert(name.to_string(), hash);
+                } else {
+                    log_warn!("images", "Invalid digest format for {}: {}", name, digest);
+                }
+            }
+        }
+    }
+
+    log_info!("images", "Loaded {} digests from GitHub releases", digests.len());
+
+    // Cache the result
+    {
+        let mut cache = DIGEST_CACHE.write().map_err(|e| format!("Cache lock error: {}", e))?;
+        *cache = Some(digests.clone());
+    }
+
+    Ok(digests)
+}
+
+/// Clear the GitHub digests cache (useful for refresh)
+#[allow(dead_code)]
+pub fn clear_digest_cache() {
+    if let Ok(mut cache) = DIGEST_CACHE.write() {
+        *cache = None;
+        log_debug!("images", "Cleared GitHub digests cache");
+    }
+}
+
+/// Look up SHA256 digest for a filename
+/// Fetches from GitHub API if not cached
+pub async fn get_digest_for_file(filename: &str) -> Option<String> {
+    match fetch_github_digests().await {
+        Ok(digests) => {
+            // Try exact match first
+            if let Some(hash) = digests.get(filename) {
+                return Some(hash.clone());
+            }
+            
+            // Try without path (just the filename)
+            let base_filename = filename.rsplit('/').next().unwrap_or(filename);
+            if let Some(hash) = digests.get(base_filename) {
+                return Some(hash.clone());
+            }
+            
+            log_debug!("images", "No digest found for filename: {}", filename);
+            None
+        }
+        Err(e) => {
+            log_warn!("images", "Failed to fetch digests: {}", e);
+            None
+        }
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,6 +159,8 @@ fn main() {
             commands::operations::flash_image,
             commands::operations::delete_downloaded_image,
             commands::operations::force_delete_cached_image,
+            commands::operations::select_save_path,
+            commands::operations::download_to_path,
             commands::progress::cancel_operation,
             commands::progress::get_download_progress,
             commands::progress::get_flash_progress,

--- a/src/components/flash/DownloadProgress.tsx
+++ b/src/components/flash/DownloadProgress.tsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useRef } from 'react';
+import { Disc, FolderOpen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { BoardInfo, ImageInfo } from '../../types';
+import { getImageLogo, getOsName } from '../../assets/os-logos';
+import {
+  selectSavePath,
+  downloadToPath,
+  getDownloadProgress,
+  cancelOperation,
+  getBoardImageUrl,
+} from '../../hooks/useTauri';
+import { ErrorDisplay, MarqueeText } from '../shared';
+import fallbackImage from '../../assets/armbian-logo_nofound.png';
+import { POLLING } from '../../config';
+import {
+  Download,
+  Archive,
+  CheckCircle,
+  XCircle,
+  ShieldCheck,
+  FolderOpen as FolderIcon,
+} from 'lucide-react';
+
+type DownloadStage =
+  | 'selecting'
+  | 'downloading'
+  | 'verifying_sha'
+  | 'decompressing'
+  | 'complete'
+  | 'error'
+  | 'cancelled';
+
+interface DownloadProgressProps {
+  board: BoardInfo;
+  image: ImageInfo;
+  decompress: boolean;
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+function DownloadStageIcon({ stage, size = 48 }: { stage: DownloadStage; size?: number }) {
+  switch (stage) {
+    case 'selecting':
+      return <FolderIcon size={size} className="stage-icon selecting" />;
+    case 'downloading':
+      return <Download size={size} className="stage-icon downloading" />;
+    case 'verifying_sha':
+      return <ShieldCheck size={size} className="stage-icon verifying-sha" />;
+    case 'decompressing':
+      return <Archive size={size} className="stage-icon decompressing" />;
+    case 'complete':
+      return <CheckCircle size={size} className="stage-icon complete" />;
+    case 'error':
+    case 'cancelled':
+      return <XCircle size={size} className="stage-icon error" />;
+  }
+}
+
+function getDownloadStageKey(stage: DownloadStage): string {
+  switch (stage) {
+    case 'selecting':
+      return 'download.selecting';
+    case 'downloading':
+      return 'download.downloading';
+    case 'verifying_sha':
+      return 'download.verifyingSha';
+    case 'decompressing':
+      return 'download.decompressing';
+    case 'complete':
+      return 'download.complete';
+    case 'cancelled':
+      return 'download.cancelled';
+    case 'error':
+      return 'download.failed';
+  }
+}
+
+export function DownloadProgress({
+  board,
+  image,
+  decompress,
+  onComplete,
+  onBack,
+}: DownloadProgressProps) {
+  const { t } = useTranslation();
+  const [stage, setStage] = useState<DownloadStage>('selecting');
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [savedPath, setSavedPath] = useState<string | null>(null);
+  const [boardImageUrl, setBoardImageUrl] = useState<string | null>(null);
+  const [imageLoadError, setImageLoadError] = useState(false);
+  const intervalRef = useRef<number | null>(null);
+  const maxProgressRef = useRef<number>(0);
+  const hasStartedRef = useRef<boolean>(false);
+  const stageRef = useRef<DownloadStage>('selecting');
+
+  // Extract filename from URL
+  function getFilenameFromUrl(url: string): string {
+    const urlPath = url.split('?')[0];
+    const parts = urlPath.split('/');
+    return parts[parts.length - 1] || 'image.img';
+  }
+
+  async function loadBoardImage() {
+    try {
+      const url = await getBoardImageUrl(board.slug);
+      setBoardImageUrl(url);
+    } catch {
+      // Ignore
+    }
+  }
+
+  // Helper to update stage and ref together
+  function updateStage(newStage: DownloadStage) {
+    stageRef.current = newStage;
+    setStage(newStage);
+  }
+
+  // Start polling for download progress
+  function startPolling() {
+    intervalRef.current = window.setInterval(async () => {
+      try {
+        const prog = await getDownloadProgress();
+
+        // Use ref to check current stage (avoids stale closure)
+        if (prog.is_verifying_sha && stageRef.current !== 'verifying_sha') {
+          updateStage('verifying_sha');
+          maxProgressRef.current = 0;
+          setProgress(0);
+        } else if (prog.is_decompressing && stageRef.current !== 'decompressing') {
+          updateStage('decompressing');
+          maxProgressRef.current = 0;
+          setProgress(0);
+        }
+
+        if (!prog.is_decompressing && !prog.is_verifying_sha) {
+          const newProgress = prog.progress_percent;
+          if (newProgress >= maxProgressRef.current) {
+            maxProgressRef.current = newProgress;
+            setProgress(newProgress);
+          }
+        }
+
+        if (prog.error) {
+          setError(prog.error);
+          updateStage('error');
+          if (intervalRef.current) clearInterval(intervalRef.current);
+        }
+      } catch {
+        // Ignore polling errors
+      }
+    }, POLLING.DOWNLOAD_PROGRESS);
+  }
+
+  async function startDownload() {
+    setProgress(0);
+    setError(null);
+    maxProgressRef.current = 0;
+
+    try {
+      // Step 1: Show save dialog and get path (no download yet)
+      const suggestedFilename = getFilenameFromUrl(image.file_url);
+      const savePath = await selectSavePath(suggestedFilename, decompress);
+      
+      if (!savePath) {
+        // User cancelled the save dialog
+        updateStage('cancelled');
+        setError(t('download.cancelled'));
+        return;
+      }
+
+      // Step 2: Now start polling (download is about to begin)
+      updateStage('downloading');
+      startPolling();
+
+      // Step 3: Start the actual download
+      const path = await downloadToPath(
+        image.file_url,
+        image.file_url_sha,
+        savePath,
+        decompress
+      );
+      
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      setSavedPath(path);
+      updateStage('complete');
+      setProgress(100);
+    } catch (err) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
+      updateStage('error');
+    }
+  }
+
+  useEffect(() => {
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
+
+    loadBoardImage();
+    startDownload();
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleCancel() {
+    try {
+      await cancelOperation();
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      onBack();
+    } catch {
+      // Ignore
+    }
+  }
+
+  async function handleRetry() {
+    setError(null);
+    hasStartedRef.current = false;
+    startDownload();
+  }
+
+  function getImageDisplayText(): string {
+    return `Armbian ${image.armbian_version} ${image.distro_release}`;
+  }
+
+  const showHeader = stage !== 'error' && stage !== 'cancelled';
+
+  return (
+    <div className={`flash-container ${!showHeader ? 'centered' : ''}`}>
+      {showHeader && (
+        <div className="flash-header">
+          <img
+            src={imageLoadError ? fallbackImage : (boardImageUrl || fallbackImage)}
+            alt={board.name}
+            className="flash-board-image"
+            onError={() => setImageLoadError(true)}
+          />
+          <div className="flash-info">
+            <h2>{board.name}</h2>
+            <div className="flash-info-badges">
+              <div className="os-badge">
+                {(() => {
+                  const logo = getImageLogo(
+                    image.distro_release,
+                    image.preinstalled_application
+                  );
+                  return logo ? (
+                    <img
+                      src={logo}
+                      alt={getOsName(image.distro_release)}
+                      className="os-badge-logo"
+                    />
+                  ) : (
+                    <Disc size={20} className="os-badge-icon" />
+                  );
+                })()}
+                <MarqueeText text={getImageDisplayText()} maxWidth={200} className="os-badge-text" />
+              </div>
+              <div className="flash-device-row">
+                <FolderOpen size={16} />
+                <span className="flash-device-name">{t('download.savingToDisk')}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className={`flash-status ${stage}`}>
+        <DownloadStageIcon stage={stage} />
+        <h3>{t(getDownloadStageKey(stage))}</h3>
+
+        {stage !== 'complete' &&
+          stage !== 'error' &&
+          stage !== 'cancelled' &&
+          stage !== 'selecting' && (
+            <div className="progress-container">
+              <div
+                className={`progress-bar ${
+                  stage === 'decompressing' || stage === 'verifying_sha' ? 'indeterminate' : ''
+                }`}
+              >
+                <div
+                  className="progress-fill"
+                  style={{
+                    width: stage === 'decompressing' || stage === 'verifying_sha' ? '100%' : `${progress}%`,
+                  }}
+                />
+              </div>
+              {stage !== 'decompressing' && stage !== 'verifying_sha' && (
+                <span className="progress-text">{progress.toFixed(0)}%</span>
+              )}
+            </div>
+          )}
+
+        {stage === 'complete' && savedPath && (
+          <p className="flash-success-hint">
+            {t('download.successHint', { path: savedPath })}
+          </p>
+        )}
+
+        {error && <ErrorDisplay error={error} />}
+
+        <div className="flash-actions-inline">
+          {stage === 'complete' && (
+            <>
+              <button className="btn btn-secondary" onClick={onBack}>
+                {t('download.downloadAnother')}
+              </button>
+              <button className="btn btn-primary" onClick={onComplete}>
+                {t('flash.done')}
+              </button>
+            </>
+          )}
+          {(stage === 'error' || stage === 'cancelled') && (
+            <>
+              <button className="btn btn-secondary" onClick={onBack}>
+                {t('flash.cancel')}
+              </button>
+              {stage === 'error' && (
+                <button className="btn btn-primary" onClick={handleRetry}>
+                  {t('flash.retry')}
+                </button>
+              )}
+            </>
+          )}
+          {stage !== 'complete' && stage !== 'error' && stage !== 'cancelled' && stage !== 'selecting' && (
+            <button className="btn btn-secondary" onClick={handleCancel}>
+              {t('flash.cancel')}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flash/index.ts
+++ b/src/components/flash/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { FlashProgress } from './FlashProgress';
+export { DownloadProgress } from './DownloadProgress';
 export { FlashActions } from './FlashActions';
 export { FlashStageIcon, getStageKey } from './FlashStageIcon';
 export type { FlashStage } from './FlashStageIcon';

--- a/src/components/modals/DeviceModal.tsx
+++ b/src/components/modals/DeviceModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { HardDrive, RefreshCw, AlertTriangle, Shield, MemoryStick, Usb } from 'lucide-react';
+import { HardDrive, RefreshCw, AlertTriangle, Shield, MemoryStick, Usb, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from './Modal';
 import { ErrorDisplay, ConfirmationDialog, ListItemSkeleton } from '../shared';
@@ -68,14 +68,16 @@ interface DeviceModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSelect: (device: BlockDevice) => void;
+  onDownloadOnly?: (decompress: boolean) => void;
 }
 
-export function DeviceModal({ isOpen, onClose, onSelect }: DeviceModalProps) {
+export function DeviceModal({ isOpen, onClose, onSelect, onDownloadOnly }: DeviceModalProps) {
   const { t } = useTranslation();
   const [selectedDevice, setSelectedDevice] = useState<BlockDevice | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
   const [showSkeleton, setShowSkeleton] = useState(false);
   const [showSystemDevices, setShowSystemDevices] = useState(false);
+  const [decompressImage, setDecompressImage] = useState(true);
 
   // Track previous devices for change detection
   const prevDevicesRef = useRef<BlockDevice[] | null>(null);
@@ -171,6 +173,23 @@ export function DeviceModal({ isOpen, onClose, onSelect }: DeviceModalProps) {
         isOpen={isOpen && !showConfirm}
         onClose={onClose}
         title={t('modal.selectDevice')}
+        footer={onDownloadOnly && (
+          <div className="modal-footer-download">
+            <span className="modal-footer-download-text">{t('modal.insteadSaveToDisk')}</span>
+            <label className="modal-footer-checkbox">
+              <input
+                type="checkbox"
+                checked={decompressImage}
+                onChange={(e) => setDecompressImage(e.target.checked)}
+              />
+              <span>{t('modal.decompressImage')}</span>
+            </label>
+            <button className="btn btn-secondary" onClick={() => onDownloadOnly(decompressImage)}>
+              <Download size={16} />
+              {t('modal.downloadOnly')}
+            </button>
+          </div>
+        )}
       >
         <div className="device-warning-banner">
           <div className="device-warning-banner-content">

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -9,9 +9,10 @@ interface ModalProps {
   searchBar?: ReactNode;
   showBack?: boolean;
   onBack?: () => void;
+  footer?: ReactNode;
 }
 
-export function Modal({ isOpen, onClose, title, children, searchBar, showBack, onBack }: ModalProps) {
+export function Modal({ isOpen, onClose, title, children, searchBar, showBack, onBack, footer }: ModalProps) {
   const [isExiting, setIsExiting] = useState(false);
   const isExitingRef = useRef(false);
 
@@ -74,6 +75,7 @@ export function Modal({ isOpen, onClose, title, children, searchBar, showBack, o
         <div className="modal-body">
           {children}
         </div>
+        {footer}
       </div>
     </div>
   );

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -37,6 +37,22 @@ export async function downloadImage(fileUrl: string, fileUrlSha?: string | null)
   return invoke('download_image', { fileUrl, fileUrlSha });
 }
 
+export async function selectSavePath(
+  suggestedFilename: string,
+  decompress: boolean = true
+): Promise<string | null> {
+  return invoke('select_save_path', { suggestedFilename, decompress });
+}
+
+export async function downloadToPath(
+  fileUrl: string,
+  fileUrlSha: string | null,
+  savePath: string,
+  decompress: boolean = true
+): Promise<string> {
+  return invoke('download_to_path', { fileUrl, fileUrlSha, savePath, decompress });
+}
+
 export async function getDownloadProgress(): Promise<DownloadProgress> {
   return invoke('get_download_progress');
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -55,7 +55,10 @@
     "allImages": "Alle Images",
     "insertDevice": "SD-Karte oder USB-Stick einstecken",
     "refreshDevices": "Geräte aktualisieren",
-    "loading": "Wird geladen..."
+    "loading": "Wird geladen...",
+    "insteadSaveToDisk": "Stattdessen auf Festplatte speichern",
+    "downloadOnly": "Nur herunterladen",
+    "decompressImage": "Image dekomprimieren"
   },
   "device": {
     "system": "System",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Dekomprimierung fehlgeschlagen",
     "uploadFailed": "Hochladen fehlgeschlagen",
     "deviceDisconnected": "Gerät wurde getrennt"
+  },
+  "download": {
+    "selecting": "Speicherort auswählen...",
+    "downloading": "Image wird heruntergeladen...",
+    "verifyingSha": "Download-Integrität wird überprüft...",
+    "decompressing": "Image wird dekomprimiert...",
+    "complete": "Download abgeschlossen!",
+    "failed": "Download fehlgeschlagen",
+    "cancelled": "Download abgebrochen",
+    "successHint": "Image gespeichert unter: {{path}}",
+    "savingToDisk": "Auf Festplatte speichern",
+    "downloadAnother": "Weiteres herunterladen"
   },
   "custom": {
     "customImage": "Benutzerdefiniertes Image"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,7 +55,10 @@
     "allImages": "All Images",
     "insertDevice": "Insert an SD card or USB drive",
     "refreshDevices": "Refresh Devices",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "insteadSaveToDisk": "Instead save to disk",
+    "downloadOnly": "Download Only",
+    "decompressImage": "Decompress image"
   },
   "device": {
     "system": "System",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Decompression failed",
     "uploadFailed": "Upload failed",
     "deviceDisconnected": "Device was disconnected"
+  },
+  "download": {
+    "selecting": "Choose save location...",
+    "downloading": "Downloading image...",
+    "verifyingSha": "Verifying download integrity...",
+    "decompressing": "Decompressing image...",
+    "complete": "Download complete!",
+    "failed": "Download failed",
+    "cancelled": "Download cancelled",
+    "successHint": "Image saved to: {{path}}",
+    "savingToDisk": "Saving to disk",
+    "downloadAnother": "Download Another"
   },
   "custom": {
     "customImage": "Custom Image"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -55,7 +55,10 @@
     "allImages": "Todas las imágenes",
     "insertDevice": "Inserte una tarjeta SD o unidad USB",
     "refreshDevices": "Actualizar dispositivos",
-    "loading": "Cargando..."
+    "loading": "Cargando...",
+    "insteadSaveToDisk": "Guardar en disco en su lugar",
+    "downloadOnly": "Solo descargar",
+    "decompressImage": "Descomprimir imagen"
   },
   "device": {
     "system": "Sistema",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Error de descompresión",
     "uploadFailed": "Error al subir",
     "deviceDisconnected": "El dispositivo fue desconectado"
+  },
+  "download": {
+    "selecting": "Elegir ubicación de guardado...",
+    "downloading": "Descargando imagen...",
+    "verifyingSha": "Verificando integridad de la descarga...",
+    "decompressing": "Descomprimiendo imagen...",
+    "complete": "¡Descarga completada!",
+    "failed": "Descarga fallida",
+    "cancelled": "Descarga cancelada",
+    "successHint": "Imagen guardada en: {{path}}",
+    "savingToDisk": "Guardando en disco",
+    "downloadAnother": "Descargar otra"
   },
   "custom": {
     "customImage": "Imagen personalizada"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -55,7 +55,10 @@
     "allImages": "Toutes les images",
     "insertDevice": "Insérez une carte SD ou une clé USB",
     "refreshDevices": "Actualiser les périphériques",
-    "loading": "Chargement..."
+    "loading": "Chargement...",
+    "insteadSaveToDisk": "Enregistrer sur le disque à la place",
+    "downloadOnly": "Télécharger uniquement",
+    "decompressImage": "Décompresser l'image"
   },
   "device": {
     "system": "Système",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Échec de la décompression",
     "uploadFailed": "Échec du téléversement",
     "deviceDisconnected": "L'appareil a été déconnecté"
+  },
+  "download": {
+    "selecting": "Choisir l'emplacement de sauvegarde...",
+    "downloading": "Téléchargement de l'image...",
+    "verifyingSha": "Vérification de l'intégrité du téléchargement...",
+    "decompressing": "Décompression de l'image...",
+    "complete": "Téléchargement terminé !",
+    "failed": "Échec du téléchargement",
+    "cancelled": "Téléchargement annulé",
+    "successHint": "Image enregistrée dans : {{path}}",
+    "savingToDisk": "Enregistrement sur le disque",
+    "downloadAnother": "Télécharger une autre"
   },
   "custom": {
     "customImage": "Image personnalisée"

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -55,7 +55,10 @@
     "allImages": "Sve slike",
     "insertDevice": "Umetnite SD karticu ili USB uređaj",
     "refreshDevices": "Osvježi uređaje",
-    "loading": "Učitavanje..."
+    "loading": "Učitavanje...",
+    "insteadSaveToDisk": "Umjesto toga spremi na disk",
+    "downloadOnly": "Samo preuzmi",
+    "decompressImage": "Raspakuj sliku"
   },
   "device": {
     "system": "Sustav",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Raspakiravanje neuspješno",
     "uploadFailed": "Slanje neuspješno",
     "deviceDisconnected": "Uređaj je isključen"
+  },
+  "download": {
+    "selecting": "Odaberi mjesto spremanja...",
+    "downloading": "Preuzimanje slike...",
+    "verifyingSha": "Provjera integriteta preuzimanja...",
+    "decompressing": "Raspakiravanje slike...",
+    "complete": "Preuzimanje završeno!",
+    "failed": "Preuzimanje neuspješno",
+    "cancelled": "Preuzimanje otkazano",
+    "successHint": "Slika spremljena u: {{path}}",
+    "savingToDisk": "Spremanje na disk",
+    "downloadAnother": "Preuzmi drugu"
   },
   "custom": {
     "customImage": "Prilagođena slika"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -55,7 +55,10 @@
     "allImages": "Tutte le Immagini",
     "insertDevice": "Inserisci una scheda SD o una chiavetta USB",
     "refreshDevices": "Aggiorna Dispositivi",
-    "loading": "Caricamento..."
+    "loading": "Caricamento...",
+    "insteadSaveToDisk": "Salva su disco invece",
+    "downloadOnly": "Solo download",
+    "decompressImage": "Decomprimi immagine"
   },
   "device": {
     "system": "Sistema",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Decompressione fallita",
     "uploadFailed": "Caricamento fallito",
     "deviceDisconnected": "Dispositivo disconnesso"
+  },
+  "download": {
+    "selecting": "Scegli posizione di salvataggio...",
+    "downloading": "Download immagine in corso...",
+    "verifyingSha": "Verifica integrità download...",
+    "decompressing": "Decompressione immagine...",
+    "complete": "Download completato!",
+    "failed": "Download fallito",
+    "cancelled": "Download annullato",
+    "successHint": "Immagine salvata in: {{path}}",
+    "savingToDisk": "Salvataggio su disco",
+    "downloadAnother": "Scarica un'altra"
   },
   "custom": {
     "customImage": "Immagine Personalizzata"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -55,7 +55,10 @@
     "allImages": "すべてのイメージ",
     "insertDevice": "SDカードまたはUSBドライブを挿入してください",
     "refreshDevices": "デバイスを更新",
-    "loading": "読み込み中..."
+    "loading": "読み込み中...",
+    "insteadSaveToDisk": "代わりにディスクに保存",
+    "downloadOnly": "ダウンロードのみ",
+    "decompressImage": "イメージを解凍"
   },
   "device": {
     "system": "システム",
@@ -94,6 +97,18 @@
     "decompressionFailed": "解凍失敗",
     "uploadFailed": "アップロード失敗",
     "deviceDisconnected": "デバイスが切断されました"
+  },
+  "download": {
+    "selecting": "保存場所を選択...",
+    "downloading": "イメージをダウンロード中...",
+    "verifyingSha": "ダウンロードの整合性を検証中...",
+    "decompressing": "イメージを解凍中...",
+    "complete": "ダウンロード完了！",
+    "failed": "ダウンロード失敗",
+    "cancelled": "ダウンロードがキャンセルされました",
+    "successHint": "イメージの保存先: {{path}}",
+    "savingToDisk": "ディスクに保存中",
+    "downloadAnother": "別のイメージをダウンロード"
   },
   "custom": {
     "customImage": "カスタムイメージ"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -55,7 +55,10 @@
     "allImages": "모든 이미지",
     "insertDevice": "SD 카드 또는 USB 드라이브를 삽입하세요",
     "refreshDevices": "장치 새로고침",
-    "loading": "로드 중..."
+    "loading": "로드 중...",
+    "insteadSaveToDisk": "대신 디스크에 저장",
+    "downloadOnly": "다운로드만",
+    "decompressImage": "이미지 압축 해제"
   },
   "device": {
     "system": "시스템",
@@ -94,6 +97,18 @@
     "decompressionFailed": "압축 해제 실패",
     "uploadFailed": "업로드 실패",
     "deviceDisconnected": "장치 연결이 해제되었습니다"
+  },
+  "download": {
+    "selecting": "저장 위치 선택...",
+    "downloading": "이미지 다운로드 중...",
+    "verifyingSha": "다운로드 무결성 확인 중...",
+    "decompressing": "이미지 압축 해제 중...",
+    "complete": "다운로드 완료!",
+    "failed": "다운로드 실패",
+    "cancelled": "다운로드 취소됨",
+    "successHint": "이미지 저장 위치: {{path}}",
+    "savingToDisk": "디스크에 저장 중",
+    "downloadAnother": "다른 이미지 다운로드"
   },
   "custom": {
     "customImage": "사용자 정의 이미지"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -55,7 +55,10 @@
     "allImages": "Alle images",
     "insertDevice": "Plaats een SD-kaart of USB-stick",
     "refreshDevices": "Apparaten vernieuwen",
-    "loading": "Laden..."
+    "loading": "Laden...",
+    "insteadSaveToDisk": "In plaats daarvan opslaan op schijf",
+    "downloadOnly": "Alleen downloaden",
+    "decompressImage": "Image uitpakken"
   },
   "device": {
     "system": "Systeem",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Uitpakken mislukt",
     "uploadFailed": "Upload mislukt",
     "deviceDisconnected": "Apparaat is losgekoppeld"
+  },
+  "download": {
+    "selecting": "Kies opslaglocatie...",
+    "downloading": "Image downloaden...",
+    "verifyingSha": "Download-integriteit controleren...",
+    "decompressing": "Image uitpakken...",
+    "complete": "Download voltooid!",
+    "failed": "Download mislukt",
+    "cancelled": "Download geannuleerd",
+    "successHint": "Image opgeslagen in: {{path}}",
+    "savingToDisk": "Opslaan op schijf",
+    "downloadAnother": "Nog een downloaden"
   },
   "custom": {
     "customImage": "Aangepaste image"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -55,7 +55,10 @@
     "allImages": "Wszystkie obrazy",
     "insertDevice": "Włóż kartę SD lub pendrive USB",
     "refreshDevices": "Odśwież urządzenia",
-    "loading": "Ładowanie..."
+    "loading": "Ładowanie...",
+    "insteadSaveToDisk": "Zamiast tego zapisz na dysku",
+    "downloadOnly": "Tylko pobierz",
+    "decompressImage": "Rozpakuj obraz"
   },
   "device": {
     "system": "System",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Rozpakowywanie nie powiodło się",
     "uploadFailed": "Przesyłanie nie powiodło się",
     "deviceDisconnected": "Urządzenie zostało odłączone"
+  },
+  "download": {
+    "selecting": "Wybierz lokalizację zapisu...",
+    "downloading": "Pobieranie obrazu...",
+    "verifyingSha": "Weryfikacja integralności pobierania...",
+    "decompressing": "Rozpakowywanie obrazu...",
+    "complete": "Pobieranie zakończone!",
+    "failed": "Pobieranie nie powiodło się",
+    "cancelled": "Pobieranie anulowane",
+    "successHint": "Obraz zapisany w: {{path}}",
+    "savingToDisk": "Zapisywanie na dysku",
+    "downloadAnother": "Pobierz kolejny"
   },
   "custom": {
     "customImage": "Własny obraz"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -55,7 +55,10 @@
     "allImages": "Todas as imagens",
     "insertDevice": "Insira um cartão SD ou pendrive USB",
     "refreshDevices": "Atualizar dispositivos",
-    "loading": "Carregando..."
+    "loading": "Carregando...",
+    "insteadSaveToDisk": "Em vez disso, salvar no disco",
+    "downloadOnly": "Apenas baixar",
+    "decompressImage": "Descompactar imagem"
   },
   "device": {
     "system": "Sistema",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Falha na descompactação",
     "uploadFailed": "Falha no envio",
     "deviceDisconnected": "Dispositivo foi desconectado"
+  },
+  "download": {
+    "selecting": "Escolher local para salvar...",
+    "downloading": "Baixando imagem...",
+    "verifyingSha": "Verificando integridade do download...",
+    "decompressing": "Descompactando imagem...",
+    "complete": "Download concluído!",
+    "failed": "Download falhou",
+    "cancelled": "Download cancelado",
+    "successHint": "Imagem salva em: {{path}}",
+    "savingToDisk": "Salvando no disco",
+    "downloadAnother": "Baixar outra"
   },
   "custom": {
     "customImage": "Imagem personalizada"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -55,7 +55,10 @@
     "allImages": "Todas as imagens",
     "insertDevice": "Insira um cartão SD ou pendrive USB",
     "refreshDevices": "Atualizar dispositivos",
-    "loading": "A carregar..."
+    "loading": "A carregar...",
+    "insteadSaveToDisk": "Em vez disso, guardar no disco",
+    "downloadOnly": "Apenas transferir",
+    "decompressImage": "Descompactar imagem"
   },
   "device": {
     "system": "Sistema",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Falha na descompactação",
     "uploadFailed": "Falha no envio",
     "deviceDisconnected": "O dispositivo foi desligado"
+  },
+  "download": {
+    "selecting": "Escolher localização de gravação...",
+    "downloading": "A transferir imagem...",
+    "verifyingSha": "A verificar integridade da transferência...",
+    "decompressing": "A descompactar imagem...",
+    "complete": "Transferência concluída!",
+    "failed": "Transferência falhou",
+    "cancelled": "Transferência cancelada",
+    "successHint": "Imagem guardada em: {{path}}",
+    "savingToDisk": "A guardar no disco",
+    "downloadAnother": "Transferir outra"
   },
   "custom": {
     "customImage": "Imagem personalizada"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -55,7 +55,10 @@
     "allImages": "Все образы",
     "insertDevice": "Вставьте SD-карту или USB-накопитель",
     "refreshDevices": "Обновить устройства",
-    "loading": "Загрузка..."
+    "loading": "Загрузка...",
+    "insteadSaveToDisk": "Сохранить на диск вместо этого",
+    "downloadOnly": "Только скачать",
+    "decompressImage": "Распаковать образ"
   },
   "device": {
     "system": "Системный",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Ошибка распаковки",
     "uploadFailed": "Ошибка загрузки",
     "deviceDisconnected": "Устройство было отключено"
+  },
+  "download": {
+    "selecting": "Выберите место сохранения...",
+    "downloading": "Загрузка образа...",
+    "verifyingSha": "Проверка целостности загрузки...",
+    "decompressing": "Распаковка образа...",
+    "complete": "Загрузка завершена!",
+    "failed": "Ошибка загрузки",
+    "cancelled": "Загрузка отменена",
+    "successHint": "Образ сохранён в: {{path}}",
+    "savingToDisk": "Сохранение на диск",
+    "downloadAnother": "Скачать другой"
   },
   "custom": {
     "customImage": "Свой образ"

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -55,7 +55,10 @@
     "allImages": "Vse slike",
     "insertDevice": "Vstavite SD kartico ali USB pogon",
     "refreshDevices": "Osveži naprave",
-    "loading": "Nalaganje..."
+    "loading": "Nalaganje...",
+    "insteadSaveToDisk": "Namesto tega shrani na disk",
+    "downloadOnly": "Samo prenesi",
+    "decompressImage": "Razširi sliko"
   },
   "device": {
     "system": "Sistemska",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Razširjanje ni uspelo",
     "uploadFailed": "Nalaganje ni uspelo",
     "deviceDisconnected": "Naprava je bila odklopljena"
+  },
+  "download": {
+    "selecting": "Izberi lokacijo shranjevanja...",
+    "downloading": "Prenašanje slike...",
+    "verifyingSha": "Preverjanje celovitosti prenosa...",
+    "decompressing": "Razširjanje slike...",
+    "complete": "Prenos končan!",
+    "failed": "Prenos ni uspel",
+    "cancelled": "Prenos preklican",
+    "successHint": "Slika shranjena v: {{path}}",
+    "savingToDisk": "Shranjevanje na disk",
+    "downloadAnother": "Prenesi drugo"
   },
   "custom": {
     "customImage": "Slika po meri"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -55,7 +55,10 @@
     "minimal": "Minimal",
     "allImages": "Alla images",
     "insertDevice": "Sätt i ett SD-kort eller USB-minne",
-    "refreshDevices": "Uppdatera enheter"
+    "refreshDevices": "Uppdatera enheter",
+    "insteadSaveToDisk": "Spara till disk istället",
+    "downloadOnly": "Endast nedladdning",
+    "decompressImage": "Packa upp image"
   },
   "device": {
     "system": "System",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Uppackning misslyckades",
     "uploadFailed": "Uppladdning misslyckades",
     "deviceDisconnected": "Enheten kopplades bort"
+  },
+  "download": {
+    "selecting": "Välj sparplats...",
+    "downloading": "Laddar ner image...",
+    "verifyingSha": "Verifierar nedladdningens integritet...",
+    "decompressing": "Packar upp image...",
+    "complete": "Nedladdning klar!",
+    "failed": "Nedladdning misslyckades",
+    "cancelled": "Nedladdning avbruten",
+    "successHint": "Image sparad till: {{path}}",
+    "savingToDisk": "Sparar till disk",
+    "downloadAnother": "Ladda ner en till"
   },
   "custom": {
     "customImage": "Egen image"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -55,7 +55,10 @@
     "allImages": "Tüm İmajlar",
     "insertDevice": "Bir SD kart veya USB sürücü takın",
     "refreshDevices": "Cihazları Yenile",
-    "loading": "Yükleniyor..."
+    "loading": "Yükleniyor...",
+    "insteadSaveToDisk": "Bunun yerine diske kaydet",
+    "downloadOnly": "Sadece indir",
+    "decompressImage": "İmajı aç"
   },
   "device": {
     "system": "Sistem",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Açma başarısız",
     "uploadFailed": "Yükleme başarısız",
     "deviceDisconnected": "Cihaz bağlantısı kesildi"
+  },
+  "download": {
+    "selecting": "Kayıt konumu seç...",
+    "downloading": "İmaj indiriliyor...",
+    "verifyingSha": "İndirme bütünlüğü doğrulanıyor...",
+    "decompressing": "İmaj açılıyor...",
+    "complete": "İndirme tamamlandı!",
+    "failed": "İndirme başarısız",
+    "cancelled": "İndirme iptal edildi",
+    "successHint": "İmaj kaydedildi: {{path}}",
+    "savingToDisk": "Diske kaydediliyor",
+    "downloadAnother": "Başka bir tane indir"
   },
   "custom": {
     "customImage": "Özel İmaj"

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -55,7 +55,10 @@
     "allImages": "Усі образи",
     "insertDevice": "Вставте SD-картку або USB-накопичувач",
     "refreshDevices": "Оновити пристрої",
-    "loading": "Завантаження..."
+    "loading": "Завантаження...",
+    "insteadSaveToDisk": "Зберегти на диск замість цього",
+    "downloadOnly": "Лише завантажити",
+    "decompressImage": "Розпакувати образ"
   },
   "device": {
     "system": "Системний",
@@ -94,6 +97,18 @@
     "decompressionFailed": "Помилка розпакування",
     "uploadFailed": "Помилка завантаження",
     "deviceDisconnected": "Пристрій було від'єднано"
+  },
+  "download": {
+    "selecting": "Виберіть місце збереження...",
+    "downloading": "Завантаження образу...",
+    "verifyingSha": "Перевірка цілісності завантаження...",
+    "decompressing": "Розпакування образу...",
+    "complete": "Завантаження завершено!",
+    "failed": "Помилка завантаження",
+    "cancelled": "Завантаження скасовано",
+    "successHint": "Образ збережено в: {{path}}",
+    "savingToDisk": "Збереження на диск",
+    "downloadAnother": "Завантажити інший"
   },
   "custom": {
     "customImage": "Власний образ"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -55,7 +55,10 @@
     "allImages": "所有镜像",
     "insertDevice": "请插入SD卡或U盘",
     "refreshDevices": "刷新设备",
-    "loading": "加载中..."
+    "loading": "加载中...",
+    "insteadSaveToDisk": "改为保存到磁盘",
+    "downloadOnly": "仅下载",
+    "decompressImage": "解压镜像"
   },
   "device": {
     "system": "系统",
@@ -94,6 +97,18 @@
     "decompressionFailed": "解压失败",
     "uploadFailed": "上传失败",
     "deviceDisconnected": "设备已断开连接"
+  },
+  "download": {
+    "selecting": "选择保存位置...",
+    "downloading": "正在下载镜像...",
+    "verifyingSha": "正在验证下载完整性...",
+    "decompressing": "正在解压镜像...",
+    "complete": "下载完成！",
+    "failed": "下载失败",
+    "cancelled": "下载已取消",
+    "successHint": "镜像已保存到：{{path}}",
+    "savingToDisk": "正在保存到磁盘",
+    "downloadAnother": "下载另一个"
   },
   "custom": {
     "customImage": "自定义镜像"

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -296,6 +296,49 @@
   gap: 6px;
 }
 
+/* Modal Footer - Download Only */
+.modal-footer-download {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-light);
+  background: var(--bg-secondary);
+}
+
+.modal-footer-download-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.modal-footer-download .btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.modal-footer-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.modal-footer-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.modal-footer-checkbox:hover {
+  color: var(--text-primary);
+}
+
 .modal-filter-bar {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
# Description

This PR does two things:
1. Add option to only download the selected image to disk
   - Toggle with checkbox for decompression option
   - Localisation for this feature in all languages supported by imager
   
   <img width="2200" height="1402" alt="CleanShot 2026-01-12 at 20 30 07@2x" src="https://github.com/user-attachments/assets/eb5762cc-680c-4ec2-b59e-6ac6fd951fe6" />

2. Fix SHA verification for armbian/os trunk images on GitHub by utilising the GitHub API which offers SHA of the artifact
   - Caches fetched api response
   - Before SHA comparison fails as there is no .sha file on dl.armbian.com for the requested Armbian-trunk...

> All features have been implemented with Claude Opus 4.5 as a guide and validated in use. Please review carefully to make sure there is no regression