### PR TITLE
refactor: conditionally hide custom image button when manufacturer is selected

### DIFF
--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -112,15 +112,17 @@ export function HomePage({
         </div>
       </div>
 
-      <div className="home-custom-section">
-        <button
-          className="home-custom-button"
-          onClick={onChooseCustomImage}
-        >
-          <FolderOpen size={16} />
-          {isCustomImage ? t('home.changeCustomImage') : t('home.useCustomImage')}
-        </button>
-      </div>
+      {!selectedManufacturer && (
+        <div className="home-custom-section">
+          <button
+            className="home-custom-button"
+            onClick={onChooseCustomImage}
+          >
+            <FolderOpen size={16} />
+            {isCustomImage ? t('home.changeCustomImage') : t('home.useCustomImage')}
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

  This PR refactors the custom image button visibility logic to create a cleaner UI flow by making the manufacturer selection and custom image paths mutually exclusive. When a manufacturer is selected, the custom image button is now hidden, and reappears when the manufacturer is deselected.

  ## Motivation

  The current UI shows both selection paths simultaneously, which can lead to user confusion and conflicting states. This change improves the user experience by:

  - **Clarifying the two distinct workflows**: Standard path (Manufacturer → Board → OS Image) vs. Custom path (Direct custom image selection)
  - **Preventing selection conflicts**: Users can't have both a manufacturer selected and use a custom image simultaneously
  - **Preparing for future features**: This refactor lays the groundwork for the upcoming board pre-setup configuration phase

  ## Changes

  - **Modified**: `src/components/layout/HomePage.tsx`
    - Wrapped custom image button section in conditional render (`!selectedManufacturer`)
    - Button now only shows when no manufacturer is selected

  ## UI Behavior

  ### Before
  - Custom image button always visible, regardless of manufacturer selection state
  - Potential confusion about interaction between the two selection paths

  ### After
  - **Initial state**: Custom image button visible
  - **Manufacturer selected**: Custom image button hidden
  - **Manufacturer deselected**: Custom image button reappears
  - **Custom image selected**: Button remains visible (since `selectedManufacturer` is null)

  ## Screenshots

<img width="1212" height="812" alt="image" src="https://github.com/user-attachments/assets/c978c4d7-f001-4bef-802a-2bd3d4bd7e4c" />