### PR TITLE
fix: reduce board image scale and improve CI cache strategy

### DIFF
--- a/.github/workflows/maintenance-pr-check.yml
+++ b/.github/workflows/maintenance-pr-check.yml
@@ -47,7 +47,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -91,7 +90,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -117,6 +115,7 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           cache-on-failure: true
+          shared-key: "v1-linux-x64"
 
       - name: Check formatting
         working-directory: src-tauri
@@ -211,15 +210,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-node-
+            ${{ runner.os }}-node-
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -229,13 +227,13 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           cache-on-failure: true
-          shared-key: ${{ matrix.platform }}
+          shared-key: "v1-${{ matrix.platform }}"
 
       - name: Cache Tauri CLI
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-tauri-${{ env.TAURI_CLI_VERSION }}
+          key: tauri-cli-${{ matrix.platform }}-${{ env.TAURI_CLI_VERSION }}
 
       - name: Install dependencies
         run: npm ci
@@ -391,7 +389,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4

--- a/src/styles/flash.css
+++ b/src/styles/flash.css
@@ -17,8 +17,8 @@
 .flash-header {
   display: flex;
   align-items: center;
-  gap: 18px;
-  padding: 18px;
+  gap: 20px;
+  padding: 20px 24px;
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   border-radius: 10px;
@@ -31,7 +31,7 @@
   height: 100px;
   object-fit: contain;
   flex-shrink: 0;
-  transform: scale(2);
+  transform: scale(1.5);
 }
 
 .flash-custom-image-icon {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -42,8 +42,8 @@
   }
 
   .flash-header {
-    gap: 14px;
-    padding: 14px;
+    gap: 16px;
+    padding: 16px 20px;
   }
 
   .flash-board-image {


### PR DESCRIPTION
## Summary

  This PR fixes the board image display issue in the flash progress screen where images were overflowing and invading the text area, making the UI appear cramped and unprofessional.

  Fixes #84

  ## Changes

  ### UI/UX Fixes
  - **Reduce board image scale**: Changed `transform: scale(2.0)` to `scale(1.5)` (effective size from 200px to 150px)
  - **Increase spacing**: Updated `.flash-header` gap from 18px → 20px
  - **Better padding**: Increased horizontal padding from 18px → 24px
  - **Responsive updates**: Proportionally adjusted breakpoints for mobile devices

  **Before**: Images were 200px effective size, causing overflow and cramped text layout
  **After**: Images are 150px effective size, properly contained with balanced spacing

  ### CI/CD Improvements
  - Removed duplicate npm cache from `setup-node` action (already using explicit cache action)
  - Simplified cache keys by removing architecture-specific components
  - Added versioned shared keys (`v1-*`) for Rust workspace cache
  - Improved cache hit rate across different runner architectures


  ## Screenshots

<img width="1162" height="687" alt="image" src="https://github.com/user-attachments/assets/16ebd770-e2db-4210-876b-cfadf725ce4f" />

  ---

  ## Notes

  - Changes are backward compatible
  - No breaking changes to existing functionality
  - CSS-only modifications for UI fixes (no React/TypeScript changes)