### PR TITLE
chore: use release-signing policy for Windows artifacts

### DIFF
--- a/.github/workflows/maintenance-release.yml
+++ b/.github/workflows/maintenance-release.yml
@@ -632,7 +632,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
           project-slug: 'imager'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ needs.build-windows-x64.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'signed-x64'
@@ -646,7 +646,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
           project-slug: 'imager'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ needs.build-windows-arm64.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'signed-arm64'


### PR DESCRIPTION
Update SignPath signing policy from test-signing to release-signing for production Windows builds (x64 and ARM64)