### PR TITLE
feat: add locked badge and disable selection for write-protected devices

### DIFF
--- a/src-tauri/src/devices/macos.rs
+++ b/src-tauri/src/devices/macos.rs
@@ -126,6 +126,7 @@ fn get_disk_info(disk_path: &str) -> Result<BlockDevice, String> {
     let mut is_removable = true;
     let mut is_internal = false;
     let mut protocol = String::new();
+    let mut is_read_only = false;
 
     for line in info.lines() {
         let line = line.trim();
@@ -151,6 +152,9 @@ fn get_disk_info(disk_path: &str) -> Result<BlockDevice, String> {
                 .nth(1)
                 .map(|s| s.trim().to_string())
                 .unwrap_or_default();
+        } else if line.starts_with("Media Read-Only:") {
+            // Check if "Media Read-Only: Yes" - indicates write-protect lock is active
+            is_read_only = line.contains("Yes");
         }
     }
 
@@ -192,5 +196,6 @@ fn get_disk_info(disk_path: &str) -> Result<BlockDevice, String> {
         is_removable,
         is_system: is_internal && !is_removable,
         bus_type,
+        is_read_only,
     })
 }

--- a/src-tauri/src/devices/types.rs
+++ b/src-tauri/src/devices/types.rs
@@ -23,4 +23,6 @@ pub struct BlockDevice {
     pub is_system: bool,
     /// Bus type (e.g., "USB", "SD", "SATA", "NVMe", "MMC")
     pub bus_type: Option<String>,
+    /// Whether the device is read-only (e.g., SD card with write-protect lock)
+    pub is_read_only: bool,
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Aktualisieren",
     "showSystemDevices": "Systemlaufwerke anzeigen",
-    "hideSystemDevices": "Systemlaufwerke ausblenden"
+    "hideSystemDevices": "Systemlaufwerke ausblenden",
+    "locked": "Gesperrt"
   },
   "header": {
     "stepManufacturer": "Hersteller",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Refresh",
     "showSystemDevices": "Show system drives",
-    "hideSystemDevices": "Hide system drives"
+    "hideSystemDevices": "Hide system drives",
+    "locked": "Locked"
   },
   "header": {
     "stepManufacturer": "Manufacturer",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Actualizar",
     "showSystemDevices": "Mostrar unidades del sistema",
-    "hideSystemDevices": "Ocultar unidades del sistema"
+    "hideSystemDevices": "Ocultar unidades del sistema",
+    "locked": "Bloqueado"
   },
   "header": {
     "stepManufacturer": "Fabricante",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Actualiser",
     "showSystemDevices": "Afficher les disques système",
-    "hideSystemDevices": "Masquer les disques système"
+    "hideSystemDevices": "Masquer les disques système",
+    "locked": "Verrouillé"
   },
   "header": {
     "stepManufacturer": "Fabricant",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Osvježi",
     "showSystemDevices": "Prikaži sustavne uređaje",
-    "hideSystemDevices": "Sakrij sustavne uređaje"
+    "hideSystemDevices": "Sakrij sustavne uređaje",
+    "locked": "Zaključano"
   },
   "header": {
     "stepManufacturer": "Proizvođač",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Aggiorna",
     "showSystemDevices": "Mostra dischi di sistema",
-    "hideSystemDevices": "Nascondi dischi di sistema"
+    "hideSystemDevices": "Nascondi dischi di sistema",
+    "locked": "Bloccato"
   },
   "header": {
     "stepManufacturer": "Produttore",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "更新",
     "showSystemDevices": "システムドライブを表示",
-    "hideSystemDevices": "システムドライブを非表示"
+    "hideSystemDevices": "システムドライブを非表示",
+    "locked": "ロック中"
   },
   "header": {
     "stepManufacturer": "メーカー",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "새로고침",
     "showSystemDevices": "시스템 드라이브 표시",
-    "hideSystemDevices": "시스템 드라이브 숨기기"
+    "hideSystemDevices": "시스템 드라이브 숨기기",
+    "locked": "잠김"
   },
   "header": {
     "stepManufacturer": "제조사",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Vernieuwen",
     "showSystemDevices": "Systeemstations weergeven",
-    "hideSystemDevices": "Systeemstations verbergen"
+    "hideSystemDevices": "Systeemstations verbergen",
+    "locked": "Vergrendeld"
   },
   "header": {
     "stepManufacturer": "Fabrikant",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Odśwież",
     "showSystemDevices": "Pokaż dyski systemowe",
-    "hideSystemDevices": "Ukryj dyski systemowe"
+    "hideSystemDevices": "Ukryj dyski systemowe",
+    "locked": "Zablokowane"
   },
   "header": {
     "stepManufacturer": "Producent",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Atualizar",
     "showSystemDevices": "Mostrar unidades do sistema",
-    "hideSystemDevices": "Ocultar unidades do sistema"
+    "hideSystemDevices": "Ocultar unidades do sistema",
+    "locked": "Bloqueado"
   },
   "header": {
     "stepManufacturer": "Fabricante",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Atualizar",
     "showSystemDevices": "Mostrar unidades do sistema",
-    "hideSystemDevices": "Ocultar unidades do sistema"
+    "hideSystemDevices": "Ocultar unidades do sistema",
+    "locked": "Bloqueado"
   },
   "header": {
     "stepManufacturer": "Fabricante",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Обновить",
     "showSystemDevices": "Показать системные диски",
-    "hideSystemDevices": "Скрыть системные диски"
+    "hideSystemDevices": "Скрыть системные диски",
+    "locked": "Заблокировано"
   },
   "header": {
     "stepManufacturer": "Производитель",

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Osveži",
     "showSystemDevices": "Prikaži sistemske pogone",
-    "hideSystemDevices": "Skrij sistemske pogone"
+    "hideSystemDevices": "Skrij sistemske pogone",
+    "locked": "Zaklenjeno"
   },
   "header": {
     "stepManufacturer": "Proizvajalec",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Uppdatera",
     "showSystemDevices": "Visa systemenheter",
-    "hideSystemDevices": "Dölj systemenheter"
+    "hideSystemDevices": "Dölj systemenheter",
+    "locked": "Låst"
   },
   "header": {
     "stepManufacturer": "Tillverkare",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Yenile",
     "showSystemDevices": "Sistem sürücülerini göster",
-    "hideSystemDevices": "Sistem sürücülerini gizle"
+    "hideSystemDevices": "Sistem sürücülerini gizle",
+    "locked": "Kilitli"
   },
   "header": {
     "stepManufacturer": "Üretici",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "Оновити",
     "showSystemDevices": "Показати системні диски",
-    "hideSystemDevices": "Приховати системні диски"
+    "hideSystemDevices": "Приховати системні диски",
+    "locked": "Заблоковано"
   },
   "header": {
     "stepManufacturer": "Виробник",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -71,7 +71,8 @@
     "nvme": "NVMe",
     "refresh": "刷新",
     "showSystemDevices": "显示系统驱动器",
-    "hideSystemDevices": "隐藏系统驱动器"
+    "hideSystemDevices": "隐藏系统驱动器",
+    "locked": "已锁定"
   },
   "header": {
     "stepManufacturer": "制造商",

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -469,6 +469,57 @@
   color: var(--text-muted);
 }
 
+/* Right section with size and badges */
+.list-item-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.list-item-size {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* Locked badge */
+.locked-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .locked-badge {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+  }
+}
+
+button.list-item.locked,
+button.list-item.system,
+button.list-item:disabled {
+  cursor: not-allowed !important;
+  opacity: 0.4 !important;
+  pointer-events: none;
+}
+
+button.list-item.locked:hover,
+button.list-item.system:hover,
+button.list-item:disabled:hover {
+  background: transparent !important;
+}
+
 .list-item-arrow {
   color: var(--text-muted);
   flex-shrink: 0;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,8 @@ export interface BlockDevice {
   is_removable: boolean;
   is_system: boolean;
   bus_type?: string;
+  /** Whether the device is read-only (e.g., SD card with write-protect lock) */
+  is_read_only?: boolean;
 }
 
 export interface DownloadProgress {

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -28,15 +28,17 @@ export function getDeviceType(device: BlockDevice): DeviceType {
   if (busType === 'nvme' || busType.includes('nvme')) return 'nvme';
   if (busType === 'sas') return 'sas';
   if (busType === 'sata' || busType === 'ata') return 'sata';
-  if (busType === 'usb') return 'usb';
+  if (busType === 'sd') return 'sd';
 
   // Path-based detection
   if (path.includes('nvme')) return 'nvme';
   if (path.includes('mmcblk') || path.includes('mmc')) return 'sd';
 
-  // Model-based detection
-  if (model.includes('sd card') || model.includes('sdcard') || model.includes('mmc')) return 'sd';
+  // Model-based detection for SD cards (check before USB to prioritize SD detection)
+  if (model.includes('sd card') || model.includes('sdcard') || model.includes('mmc') ||
+      model.includes('sdxc') || model.includes('sdhc') || model.includes('sd reader')) return 'sd';
   if (model.includes('ssd') || model.includes('nvme')) return 'nvme';
+  if (busType === 'usb') return 'usb';
   if (model.includes('usb') || model.includes('flash')) return 'usb';
 
   // Fallback based on removability


### PR DESCRIPTION
## Summary                                                                                                                                                                 
                                                                                                                                                                             
  Add visual indicator and selection blocking for write-protected storage devices (SD cards with physical lock switch).                                                      
                                                                                                                                                                             
  ## Changes                                                                                                                                                                 
                                                                                                                                                                             
  - **Backend**: Detect write-protection status on all platforms                                                                                                             
    - macOS: via `diskutil info` (MediaWritable property)                                                                                                                    
    - Linux: via sysfs `/sys/block/{device}/ro`                                                                                                                              
    - Windows: via `IOCTL_STORAGE_GET_MEDIA_TYPES_EX` (MEDIA_WRITE_PROTECTED flag)                                                                                           
  - **Frontend**: Display "Locked" badge for read-only devices                                                                                                               
  - **UX**: Disable selection of system and write-protected devices with visual feedback                                                                                     
  - **Fix**: Improved SD card detection for SDXC/SDHC readers                                                                                                                
  - **i18n**: Added `device.locked` translation key in all 18 languages                                                                                                      
                                                                                                                                                                             
  ## Screenshot                                                                                                                                                              
                                                                                                                                                                             
  <img width="1212" height="812" alt="image" src="https://github.com/user-attachments/assets/16d3d924-7a52-4a65-807a-116ecc565e3f" />                                        
                                                                                                                                                                             
  ## Test Plan                                                                                                                                                               
                                                                                                                                                                             
  - [x] Insert SD card with lock switch ON → should show "Locked" badge and be non-selectable                                                                                
  - [x] Insert SD card with lock switch OFF → should be selectable normally                                                                                                  
  - [x] Toggle "Show system drives" → system drives appear faded and non-selectable                                                                                          
  - [ ] Verify on macOS, Linux, Windows                                                                                                                                      
                                                                                                                                                                             
  ## Technical Notes                                                                                                                                                         
                                                                                                                                                                             
  ### Windows Write-Protection Detection                                                                                                                                     
                                                                                                                                                                             
  Uses `IOCTL_STORAGE_GET_MEDIA_TYPES_EX` instead of `IOCTL_DISK_IS_WRITABLE` because:                                                                                       
  - `IOCTL_DISK_IS_WRITABLE` only checks driver capability, not physical lock state                                                                                          
  - `IOCTL_STORAGE_GET_MEDIA_TYPES_EX` exposes `MediaCharacteristics` with `MEDIA_WRITE_PROTECTED` flag (0x100)                                                              
                                                                                                                                                                             
  **Note**: Some cheap USB card readers may not report lock switch status to the OS (hardware limitation). 