### PR TITLE
fix: align macOS ARM artifact naming to aarch64 (#99)

### DIFF
--- a/.github/workflows/maintenance-build.yml
+++ b/.github/workflows/maintenance-build.yml
@@ -180,7 +180,7 @@ jobs:
             arch: x64
             os: macos-15
           - target: aarch64-apple-darwin
-            arch: arm64
+            arch: aarch64
             os: macos-latest
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/maintenance-release.yml
+++ b/.github/workflows/maintenance-release.yml
@@ -234,7 +234,7 @@ jobs:
             arch: x64
             os: macos-15
           - target: aarch64-apple-darwin
-            arch: arm64
+            arch: aarch64
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
@@ -793,9 +793,9 @@ jobs:
           fi
 
           # macOS ARM64
-          MAC_ARM_SIG=$(get_sig "Armbian.Imager.app-arm64.tar.gz" || echo "")
+          MAC_ARM_SIG=$(get_sig "Armbian.Imager.app-aarch64.tar.gz" || echo "")
           if [[ -n "$MAC_ARM_SIG" ]]; then
-            PLATFORMS["darwin-aarch64"]="{\"signature\": \"${MAC_ARM_SIG}\", \"url\": \"${BASE_URL}/Armbian.Imager.app-arm64.tar.gz\"}"
+            PLATFORMS["darwin-aarch64"]="{\"signature\": \"${MAC_ARM_SIG}\", \"url\": \"${BASE_URL}/Armbian.Imager.app-aarch64.tar.gz\"}"
           fi
 
           # Linux x64


### PR DESCRIPTION
## Summary                                                                                                                                                                        
  - Rename macOS ARM matrix `arch` from `arm64` to `aarch64` in both `maintenance-build.yml` and `maintenance-release.yml`                                                          
  - Update hardcoded update manifest references from `Armbian.Imager.app-arm64.tar.gz` to `Armbian.Imager.app-aarch64.tar.gz`                                                       
                                                                                                                                                                                    
  ## Why                                                                                                                                                                            
                                                                                                                                                                                    
  The DMG produced by Tauri's bundler derives its name from the Rust target triple `aarch64-apple-darwin`, resulting in an `aarch64` suffix. However, the `.app.zip` and `.tar.gz`  
  artifacts were using `arm64` from the matrix config, creating inconsistent naming across output formats.

  Since `arm64` and `aarch64` refer to the same architecture, this aligns everything to `aarch64` for consistency.

  ## Affected artifacts (ARM builds)

  | Before | After |
  |--------|-------|
  | `Armbian.Imager-arm64.app.zip` | `Armbian.Imager-aarch64.app.zip` |
  | `Armbian.Imager.app-arm64.tar.gz` | `Armbian.Imager.app-aarch64.tar.gz` |
  | `Armbian.Imager_x.y.z_aarch64.dmg` | `Armbian.Imager_x.y.z_aarch64.dmg` (unchanged) |

  Ref: https://github.com/armbian/imager/issues/99