### PR TITLE
fix(ci): fix Dependabot not creating PRs for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,9 +68,6 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
-    # Separate PRs for each action
-    groups: []
-    versioning-strategy: "increase"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

- Remove `groups: []` — invalid YAML type (must be a mapping, not an array), caused Dependabot to silently skip the entire github-actions ecosystem entry
- Remove `versioning-strategy: "increase"` — not supported for github-actions ecosystem ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference))

## Context

Dependabot has **never** created a single PR for github-actions despite the config being present. After this fix, it should start proposing updates (e.g. `actions/setup-node@v4` → `@v6`).

## Test plan

- [ ] Verify Dependabot creates github-actions PRs on next scheduled run (Monday 09:00 UTC)