### PR TITLE
feat(api): migrate to api.armbian.com REST v1

### DIFF
--- a/src-tauri/src/commands/board_queries.rs
+++ b/src-tauri/src/commands/board_queries.rs
@@ -1,6 +1,6 @@
 //! Board and image queries module
 //!
-//! Handles fetching and filtering board/image data.
+//! Handles fetching and filtering board/image data from the Armbian REST API.
 
 use std::collections::HashSet;
 use std::sync::Mutex;
@@ -8,10 +8,11 @@ use std::sync::Mutex;
 use once_cell::sync::Lazy;
 use tauri::State;
 
+use crate::config;
 use crate::devices::{get_block_devices as devices_get_block_devices, BlockDevice};
 use crate::images::{
-    extract_images, fetch_all_images, filter_images_for_board, get_unique_boards, BoardInfo,
-    ImageInfo,
+    fetch_boards, fetch_images_for_board, fetch_vendors, map_board, map_images, ApiVendor,
+    BoardInfo, ImageInfo,
 };
 use crate::{log_debug, log_error, log_info};
 
@@ -20,86 +21,114 @@ use super::state::AppState;
 /// Track previously seen device paths to detect changes
 static PREV_DEVICE_PATHS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
-/// Get list of available boards
+/// Get list of available boards from the Armbian REST API
 #[tauri::command]
 pub async fn get_boards(state: State<'_, AppState>) -> Result<Vec<BoardInfo>, String> {
-    log_info!("board_queries", "Fetching boards list");
+    log_debug!("board_queries", "Fetching boards list");
 
-    // Fetch images if not cached
-    let mut json_guard = state.images_json.lock().await;
-    if json_guard.is_none() {
-        log_info!("board_queries", "Cache miss - fetching from API");
-        let json = fetch_all_images().await.map_err(|e| {
+    // Fetch boards if not cached
+    let mut boards_guard = state.boards.lock().await;
+    if boards_guard.is_none() {
+        log_debug!("board_queries", "Cache miss - fetching from API");
+        let api_boards = fetch_boards().await.map_err(|e| {
             log_error!("board_queries", "Failed to fetch boards: {}", e);
             e
         })?;
-        *json_guard = Some(json);
+        *boards_guard = Some(api_boards);
     }
 
-    let json = json_guard.as_ref().unwrap();
-    let images = extract_images(json);
-    let boards = get_unique_boards(&images);
-    log_info!("board_queries", "Found {} boards", boards.len());
+    let api_boards = boards_guard
+        .as_ref()
+        .ok_or_else(|| "Boards cache was not populated after fetch".to_string())?;
+    let boards: Vec<BoardInfo> = api_boards.iter().map(map_board).collect();
+    log_debug!("board_queries", "Found {} boards", boards.len());
     Ok(boards)
 }
 
-/// Get images available for a specific board
+/// Get images available for a specific board from the Armbian REST API
 #[tauri::command]
 pub async fn get_images_for_board(
     board_slug: String,
     preapp_filter: Option<String>,
     kernel_filter: Option<String>,
     variant_filter: Option<String>,
-    stable_only: bool,
-    state: State<'_, AppState>,
+    stability: Option<String>,
 ) -> Result<Vec<ImageInfo>, String> {
-    log_info!(
-        "board_queries",
-        "Getting images for board: {} (stable_only: {})",
-        board_slug,
-        stable_only
-    );
     log_debug!(
         "board_queries",
-        "Filters - preapp: {:?}, kernel: {:?}, variant: {:?}",
+        "Getting images for board: {} (stability: {:?}, preapp: {:?}, kernel: {:?}, variant: {:?})",
+        board_slug,
+        stability,
         preapp_filter,
         kernel_filter,
         variant_filter
     );
 
-    let json_guard = state.images_json.lock().await;
-    let json = json_guard.as_ref().ok_or_else(|| {
+    // Fetch from API with server-side filters where possible
+    let api_images = fetch_images_for_board(
+        &board_slug,
+        variant_filter.as_deref(),
+        None, // distribution filter not used in current UI
+        kernel_filter.as_deref(),
+        None, // promoted filter not used directly
+    )
+    .await
+    .map_err(|e| {
         log_error!(
             "board_queries",
-            "Images not loaded when requesting board: {}",
-            board_slug
+            "Failed to fetch images for board {}: {}",
+            board_slug,
+            e
         );
-        "Images not loaded. Call get_boards first.".to_string()
+        e
     })?;
 
-    let images = extract_images(json);
-    log_debug!("board_queries", "Total images available: {}", images.len());
-    let filtered = filter_images_for_board(
-        &images,
-        &board_slug,
-        preapp_filter.as_deref(),
-        kernel_filter.as_deref(),
-        variant_filter.as_deref(),
-        stable_only,
-    );
+    // Map API images to frontend-facing types
+    let mut images = map_images(api_images);
+
+    // Apply client-side filters that aren't supported by the API
+    if let Some(ref filter) = preapp_filter {
+        if filter == config::images::EMPTY_FILTER {
+            images.retain(|img| img.preinstalled_application.is_empty());
+        } else {
+            images.retain(|img| img.preinstalled_application == *filter);
+        }
+    }
+
+    if let Some(ref filter) = stability {
+        images.retain(|img| img.stability == *filter);
+    }
+
     log_debug!(
         "board_queries",
-        "Filtered down to {} images for board {}",
-        filtered.len(),
-        board_slug
-    );
-    log_info!(
-        "board_queries",
         "Found {} images for board {}",
-        filtered.len(),
+        images.len(),
         board_slug
     );
-    Ok(filtered)
+    Ok(images)
+}
+
+/// Get list of vendors/manufacturers from the Armbian REST API
+#[tauri::command]
+pub async fn get_vendors(state: State<'_, AppState>) -> Result<Vec<ApiVendor>, String> {
+    log_debug!("board_queries", "Fetching vendors list");
+
+    let mut vendors_guard = state.vendors.lock().await;
+    if vendors_guard.is_none() {
+        log_debug!("board_queries", "Vendors cache miss - fetching from API");
+        let api_vendors = fetch_vendors().await.map_err(|e| {
+            log_error!("board_queries", "Failed to fetch vendors: {}", e);
+            e
+        })?;
+        *vendors_guard = Some(api_vendors);
+    }
+
+    let vendors = vendors_guard
+        .as_ref()
+        .ok_or_else(|| "Vendors cache was not populated after fetch".to_string())?
+        .clone();
+    log_debug!("board_queries", "Found {} vendors", vendors.len());
+    Ok(vendors)
 }
 
 /// Get available block devices

--- a/src-tauri/src/commands/custom_image.rs
+++ b/src-tauri/src/commands/custom_image.rs
@@ -8,10 +8,10 @@ use tauri::State;
 
 use crate::config;
 use crate::decompress::{decompress_local_file, needs_decompression};
-use crate::images::{extract_images, fetch_all_images, get_unique_boards, BoardInfo};
+use crate::images::{fetch_boards, map_board, BoardInfo};
 use crate::qdl::extract::open_tar_reader;
 use crate::utils::{get_cache_dir, normalize_slug, parse_armbian_filename};
-use crate::{log_error, log_info};
+use crate::{log_debug, log_error, log_info};
 
 use super::state::AppState;
 
@@ -28,7 +28,7 @@ pub struct CustomImageInfo {
 pub async fn check_needs_decompression(image_path: String) -> Result<bool, String> {
     let path = PathBuf::from(&image_path);
     let needs = needs_decompression(&path);
-    log_info!(
+    log_debug!(
         "custom_image",
         "Check decompression for {}: {}",
         image_path,
@@ -195,7 +195,7 @@ pub async fn check_is_qdl_image(image_path: String) -> Result<bool, String> {
 
     // For plain .tar files, full content inspection is fast
     if filename.ends_with(".tar") {
-        log_info!(
+        log_debug!(
             "custom_image",
             "Checking plain TAR for QDL structure: {}",
             image_path
@@ -205,7 +205,7 @@ pub async fn check_is_qdl_image(image_path: String) -> Result<bool, String> {
             Err(_) => return Ok(false),
         };
         let has_qdl = check_tar_for_qdl(reader);
-        log_info!("custom_image", "Archive has QDL structure: {}", has_qdl);
+        log_debug!("custom_image", "Archive has QDL structure: {}", has_qdl);
         return Ok(has_qdl);
     }
 
@@ -216,7 +216,7 @@ pub async fn check_is_qdl_image(image_path: String) -> Result<bool, String> {
     // .img.xz). The actual QDL file structure is validated after full extraction
     // in the flash pipeline (extract.rs::validate_required_files).
     if filename.contains(".tar.") {
-        log_info!(
+        log_debug!(
             "custom_image",
             "Checking compressed TAR validity: {}",
             image_path
@@ -226,7 +226,7 @@ pub async fn check_is_qdl_image(image_path: String) -> Result<bool, String> {
             Err(_) => return Ok(false),
         };
         let has_qdl = quick_check_qdl_structure(reader);
-        log_info!("custom_image", "QDL structure detected: {}", has_qdl);
+        log_debug!("custom_image", "QDL structure detected: {}", has_qdl);
         return Ok(has_qdl);
     }
 
@@ -327,24 +327,24 @@ pub async fn detect_board_from_filename(
     filename: String,
     state: State<'_, AppState>,
 ) -> Result<Option<BoardInfo>, String> {
-    log_info!(
+    log_debug!(
         "custom_image",
-        "=== Starting board detection from filename: {} ===",
+        "Starting board detection from filename: {}",
         filename
     );
 
-    // 1. Extract filename from path (remove directory)
+    // Extract filename from path (remove directory)
     let path = PathBuf::from(&filename);
     let filename_only = path
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or("Invalid filename")?;
 
-    // 2. Parse Armbian filename using shared utility
+    // Parse Armbian filename using shared utility
     let parsed = match parse_armbian_filename(filename_only) {
         Some(info) => info,
         None => {
-            log_info!(
+            log_debug!(
                 "custom_image",
                 "Not an Armbian image or invalid format: {}",
                 filename_only
@@ -353,74 +353,51 @@ pub async fn detect_board_from_filename(
         }
     };
 
-    log_info!(
+    log_debug!(
         "custom_image",
         "Extracted board slug from filename: {}",
         parsed.board_slug
     );
 
-    // 3. Normalize board slug for matching against API data
+    // Normalize board slug for matching against API data
     let normalized_slug = normalize_slug(&parsed.board_slug);
-    log_info!("custom_image", "Normalized board slug: {}", normalized_slug);
+    log_debug!("custom_image", "Normalized board slug: {}", normalized_slug);
 
-    // 7. Ensure board data is loaded (auto-load if not cached)
-    // Use compare-and-swap pattern to prevent race conditions
-    log_info!("custom_image", "Checking if board data is cached...");
+    // Ensure board data is loaded (auto-load if not cached)
     {
         let needs_loading = {
-            let json_guard = state.images_json.lock().await;
-            json_guard.is_none()
+            let boards_guard = state.boards.lock().await;
+            boards_guard.is_none()
         };
 
         if needs_loading {
-            log_info!(
-                "custom_image",
-                "Board data not cached, fetching from API..."
-            );
-            let json = fetch_all_images().await.map_err(|e| {
+            log_debug!("custom_image", "Board data not cached, fetching from API");
+            let api_boards = fetch_boards().await.map_err(|e| {
                 log_error!("custom_image", "Failed to fetch board data: {}", e);
                 format!("Failed to fetch board data: {}", e)
             })?;
 
             // Cache the fetched data
-            let mut json_guard = state.images_json.lock().await;
-            // Double-check: another thread might have loaded it while we were fetching
-            if json_guard.is_none() {
-                *json_guard = Some(json);
-                log_info!("custom_image", "Board data cached successfully");
-            } else {
-                log_info!(
-                    "custom_image",
-                    "Board data was already cached by another thread"
-                );
+            let mut boards_guard = state.boards.lock().await;
+            if boards_guard.is_none() {
+                *boards_guard = Some(api_boards);
             }
         }
     }
 
-    // 8. Get cached boards data (now guaranteed to be loaded)
-    // Extract boards in a scoped block to release lock early
+    // Get cached boards data (now guaranteed to be loaded)
     let matching_board = {
-        log_info!("custom_image", "Accessing cached board data...");
-        let json_guard = state.images_json.lock().await;
-        let json = json_guard.as_ref().ok_or("Images not loaded")?;
+        let boards_guard = state.boards.lock().await;
+        let api_boards = boards_guard.as_ref().ok_or("Boards not loaded")?;
 
-        log_info!("custom_image", "Loaded images JSON, extracting boards...");
-        let images = extract_images(json);
-        log_info!("custom_image", "Extracted {} images", images.len());
-        let boards = get_unique_boards(&images);
-        log_info!(
-            "custom_image",
-            "Found {} unique boards in database",
-            boards.len()
-        );
-        // Lock released here
+        let boards: Vec<BoardInfo> = api_boards.iter().map(map_board).collect();
+        log_debug!("custom_image", "Found {} boards in database", boards.len());
 
-        // 9. Find matching board by slug
+        // Find matching board by slug
         boards
-            .iter()
+            .into_iter()
             .find(|board| board.slug == normalized_slug)
-            .cloned()
-    }; // matching_board is now owned, lock is released
+    };
 
     if let Some(ref board) = matching_board {
         log_info!(
@@ -437,6 +414,5 @@ pub async fn detect_board_from_filename(
         );
     }
 
-    log_info!("custom_image", "Board detection completed successfully");
     Ok(matching_board)
 }

--- a/src-tauri/src/commands/operations.rs
+++ b/src-tauri/src/commands/operations.rs
@@ -54,7 +54,7 @@ pub async fn request_write_authorization(device_path: String) -> Result<bool, St
 #[tauri::command]
 pub async fn download_image(
     file_url: String,
-    file_url_sha: Option<String>,
+    sha_url: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     log_info!("operations", "Starting download: {}", file_url);
@@ -63,22 +63,18 @@ pub async fn download_image(
         "Download directory: {:?}",
         get_cache_dir(config::app::NAME).join("images")
     );
-    if let Some(ref sha) = file_url_sha {
-        log_info!("operations", "SHA URL: {}", sha);
+    if let Some(ref sha) = sha_url {
+        log_debug!("operations", "SHA URL: {}", sha);
     } else {
-        log_info!("operations", "No SHA URL provided");
-        log_debug!("operations", "SHA verification will be skipped");
+        log_debug!(
+            "operations",
+            "No SHA URL provided; verification will be skipped"
+        );
     }
     let download_dir = get_cache_dir(config::app::NAME).join("images");
 
     let download_state = state.download_state.clone();
-    let result = do_download(
-        &file_url,
-        file_url_sha.as_deref(),
-        &download_dir,
-        download_state,
-    )
-    .await;
+    let result = do_download(&file_url, sha_url.as_deref(), &download_dir, download_state).await;
 
     match &result {
         Ok(path) => {

--- a/src-tauri/src/commands/scraping.rs
+++ b/src-tauri/src/commands/scraping.rs
@@ -1,7 +1,7 @@
 //! Asset caching module
 //!
 //! Serves board images and vendor logos from the local picture cache
-//! as base64 data URIs, downloading from cache.armbian.com on first access.
+//! as base64 data URIs, downloading from the Armbian API on first access.
 
 use crate::config;
 use crate::picture_cache;
@@ -35,14 +35,12 @@ pub async fn get_cached_board_image(board_slug: String) -> Result<Option<String>
 /// or `None` if the logo is unavailable (offline and not cached).
 ///
 /// # Arguments
-/// * `vendor_id` - Vendor identifier for cache key
-/// * `logo_url` - Full remote URL for the vendor logo
+/// * `vendor_slug` - Vendor identifier used to construct the logo URL
 #[tauri::command]
-pub async fn get_cached_vendor_logo(
-    vendor_id: String,
-    logo_url: String,
-) -> Result<Option<String>, String> {
-    let path = picture_cache::get_asset("vendors", &vendor_id, &logo_url).await;
+pub async fn get_cached_vendor_logo(vendor_slug: String) -> Result<Option<String>, String> {
+    let url = format!("{}{}.png", config::urls::VENDOR_IMAGES_BASE, vendor_slug);
+
+    let path = picture_cache::get_asset("vendors", &vendor_slug, &url).await;
     match path {
         Some(p) => Ok(picture_cache::read_as_data_uri(&p).await),
         None => Ok(None),

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -7,10 +7,14 @@ use tokio::sync::Mutex;
 
 use crate::download::DownloadState;
 use crate::flash::FlashState;
+use crate::images::{ApiBoardSummary, ApiVendor};
 
 /// Application state shared across all commands
 pub struct AppState {
-    pub images_json: Mutex<Option<serde_json::Value>>,
+    /// Cached board list from the REST API
+    pub boards: Mutex<Option<Vec<ApiBoardSummary>>>,
+    /// Cached vendor list from the REST API
+    pub vendors: Mutex<Option<Vec<ApiVendor>>>,
     pub download_state: Arc<DownloadState>,
     pub flash_state: Arc<FlashState>,
 }
@@ -18,7 +22,8 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            images_json: Mutex::new(None),
+            boards: Mutex::new(None),
+            vendors: Mutex::new(None),
             download_state: Arc::new(DownloadState::new()),
             flash_state: Arc::new(FlashState::new()),
         }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -40,7 +40,7 @@ pub fn log_debug_from_frontend(module: String, message: String) {
 #[tauri::command]
 pub fn get_system_locale() -> String {
     let locale = get_locale().unwrap_or_else(|| "en-US".to_string());
-    log_info!(MODULE, "Detected system locale: {}", locale);
+    log_debug!(MODULE, "Detected system locale: {}", locale);
     locale
 }
 
@@ -209,12 +209,12 @@ fn open_url_windows(url: &str) -> Result<(), String> {
 
 /// Check if the application can reach the Armbian API
 ///
-/// Performs a HEAD request to the images API with a 5-second timeout.
+/// Performs a GET request to the API health endpoint with a 5-second timeout.
 /// Returns true if reachable, false if offline or any error occurs.
 #[tauri::command]
 pub async fn check_connectivity() -> bool {
     match CONNECTIVITY_CLIENT
-        .head(crate::config::urls::ALL_IMAGES)
+        .get(crate::config::urls::HEALTH)
         .send()
         .await
     {
@@ -269,7 +269,7 @@ pub fn get_armbian_release() -> Option<ArmbianReleaseInfo> {
 
         // Check if file exists
         if !std::path::Path::new(path).exists() {
-            log_info!(MODULE, "{} not found - not running on Armbian", path);
+            log_debug!(MODULE, "{} not found - not running on Armbian", path);
             return None;
         }
 

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -19,14 +19,20 @@ pub mod app {
 
 /// API endpoints and URLs
 pub mod urls {
-    /// Armbian all-images JSON endpoint
-    pub const ALL_IMAGES: &str = "https://github.armbian.com/armbian-images.json";
+    /// Armbian REST API base URL
+    pub const API_BASE: &str = "https://api.armbian.com/api/v1";
 
-    /// Base URL for board images (cache.armbian.com/images/{size}/{board_slug}.png)
-    pub const BOARD_IMAGES_BASE: &str = "https://cache.armbian.com/images/";
+    /// Health check endpoint (no auth required)
+    pub const HEALTH: &str = "https://api.armbian.com/api/v1/health";
 
-    /// Default image size for board photos (272px width, natural aspect ratio)
-    pub const BOARD_IMAGE_SIZE: &str = "272";
+    /// Base URL for board images (api.armbian.com/api/v1/images/boards/{size}/{slug}.png)
+    pub const BOARD_IMAGES_BASE: &str = "https://api.armbian.com/api/v1/images/boards/";
+
+    /// Default image size for board photos (480px width, natural aspect ratio)
+    pub const BOARD_IMAGE_SIZE: &str = "480";
+
+    /// Base URL for vendor logos (api.armbian.com/api/v1/images/vendors/{size}/{slug}.png)
+    pub const VENDOR_IMAGES_BASE: &str = "https://api.armbian.com/api/v1/images/vendors/480/";
 }
 
 /// Download and decompression settings
@@ -117,6 +123,12 @@ pub mod http {
 
     /// Short timeout for quick requests like board info (10 seconds)
     pub const SHORT_TIMEOUT_SECS: u64 = 10;
+
+    /// Client identification header name for the Armbian REST API
+    pub const CLIENT_HEADER_NAME: &str = "X-Armbian-Client";
+
+    /// Client identification header value for the Armbian Imager
+    pub const CLIENT_HEADER_VALUE: &str = "armbian-imager";
 }
 
 /// Image filtering constants

--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -1,430 +1,78 @@
-//! Image filtering and extraction
+//! API data mappers
 //!
-//! Functions for parsing and filtering image data.
+//! Simple mapping functions that convert API response types into
+//! frontend-facing types. The new REST API returns pre-processed data,
+//! so no complex extraction, validation, or deduplication is needed.
 
-use std::collections::HashMap;
+use super::models::{
+    ApiBoardSummary, ApiImage, BoardInfo, CompanionInfo, DisplayVariantInfo, ImageInfo,
+};
 
-use crate::config;
-use crate::log_info;
-use crate::utils::normalize_slug;
-
-use super::models::{ArmbianImage, BoardInfo, ImageInfo};
-
-/// Capitalize vendor ID for display (e.g., "rockchip" -> "Rockchip", "intel-amd" -> "Intel-Amd")
-fn capitalize_vendor(vendor: &str) -> String {
-    if vendor == "other" {
-        return "Other".to_string();
+/// Map an API board summary to a frontend-facing BoardInfo
+pub fn map_board(api: &ApiBoardSummary) -> BoardInfo {
+    BoardInfo {
+        slug: api.slug.clone(),
+        name: api.name.clone(),
+        vendor: api.vendor_slug.clone(),
+        vendor_name: api.vendor_name.clone(),
+        support_tier: api.support_tier.clone(),
+        image_count: api.image_count as usize,
+        has_desktop: api.has_desktop,
+        promoted: api.promoted,
+        soc: api.soc.clone(),
+        architecture: api.architecture.clone(),
+        summary: api.summary.clone(),
     }
-    vendor
-        .split('-')
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("-")
 }
 
-/// Check if a file (extension + url) represents a valid flashable image
-///
-/// The Armbian API uses `file_extension` inconsistently:
-/// - Most entries have compound extensions like `img.xz`, `tar.xz`, `oowow.img.xz`
-/// - Some entries (e.g., arduino-uno-q) have only `xz` and the real extension
-///   is inside the filename (e.g., `...trixie_edge_6.19.0_minimal.tar.xz`)
-/// - Some supplementary files use compound extensions too — FIP firmware uses
-///   `img.xz` (with `.fip.img.xz` URL) and LK bootloaders use bare `xz` (with
-///   `.lk.bin.xz` URL). Both must NOT appear as flashable images.
-///
-/// We apply two checks: reject supplementary patterns in the URL first, then
-/// accept compound image/archive extensions OR bare compression extensions
-/// whose URL contains a flashable pattern.
-fn is_valid_image_file(ext: &str, file_url: Option<&str>) -> bool {
-    let ext_lower = ext.to_lowercase();
+/// Map a list of API images to frontend-facing ImageInfo, sorted by promoted first then release
+pub fn map_images(api_images: Vec<ApiImage>) -> Vec<ImageInfo> {
+    let mut images: Vec<ImageInfo> = api_images.iter().map(map_image).collect();
 
-    // Exclude metadata/signature files
-    if ext_lower.contains("asc") || ext_lower.contains("torrent") || ext_lower.contains("sha") {
-        return false;
-    }
+    // Sort: promoted first, then by release version descending
+    images.sort_by(|a, b| match (a.promoted, b.promoted) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => b.release.cmp(&a.release),
+    });
 
-    // Exclude partial/specialized images that aren't complete flashable OS images:
-    // - ufs.img.xz / ufs.xz: UFS filesystem images (alternative storage format)
-    // - rootfs.img.xz: Root filesystem only (no bootloader)
-    // - recovery.img.xz: Recovery partitions
-    // - kebab/csot/boe.img.xz: Display panel firmware variants
-    // - hyperv.zip: Hyper-V packages (not a disk image)
-    if ext_lower.starts_with("ufs")
-        || ext_lower.starts_with("rootfs")
-        || ext_lower.starts_with("recovery")
-        || ext_lower.starts_with("kebab")
-        || ext_lower.starts_with("csot")
-        || ext_lower.starts_with("boe")
-        || ext_lower.contains("hyperv")
-    {
-        return false;
-    }
-
-    // Reject supplementary blobs by URL pattern regardless of extension.
-    // Examples: *.lk.bin.xz (LK bootloader), *.fip.img.xz (firmware package),
-    // *.boot.img.xz (boot image), *.u-boot.img.xz (U-Boot binary).
-    if let Some(url) = file_url {
-        let url_lower = url.to_lowercase();
-        if url_lower.contains(".lk.bin.")
-            || url_lower.contains(".fip.")
-            || url_lower.contains(".boot.img.")
-            || url_lower.contains(".u-boot.")
-        {
-            return false;
-        }
-    }
-
-    // Compound extensions are self-describing
-    if ext_lower.contains("img")
-        || ext_lower.contains("iso")
-        || ext_lower.contains("raw")
-        || ext_lower.contains("tar")
-    {
-        return true;
-    }
-
-    // Bare compression extension: verify the URL contains a flashable pattern
-    // (real extension is inside the filename, e.g., `...minimal.tar.xz`)
-    let is_bare_compression = matches!(ext_lower.as_str(), "xz" | "gz" | "bz2" | "zst");
-    if is_bare_compression {
-        if let Some(url) = file_url {
-            let url_lower = url.to_lowercase();
-            return url_lower.contains(".tar.")
-                || url_lower.contains(".img.")
-                || url_lower.contains(".iso.")
-                || url_lower.contains(".raw.");
-        }
-    }
-
-    false
-}
-
-/// Known board slugs that require QDL (Qualcomm EDL) flashing
-const QDL_BOARD_SLUGS: &[&str] = &["arduino-uno-q"];
-
-/// Determine the flash method for an image based on API field, extension, or board slug
-fn determine_flash_method(img: &ArmbianImage) -> String {
-    // 1. Use explicit flash_method from API if present
-    if let Some(ref method) = img.flash_method {
-        if !method.is_empty() {
-            return method.clone();
-        }
-    }
-
-    // 2. Infer from file extension: .tar without .img → QDL
-    if let Some(ref ext) = img.file_extension {
-        let ext_lower = ext.to_lowercase();
-        if ext_lower.contains("tar") && !ext_lower.contains("img") {
-            return "qdl".to_string();
-        }
-    }
-
-    // 3. Infer from board slug: known QDL boards
-    if let Some(ref slug) = img.board_slug {
-        let normalized = crate::utils::normalize_slug(slug);
-        if QDL_BOARD_SLUGS
-            .iter()
-            .any(|&s| normalized == normalize_slug(s))
-        {
-            return "qdl".to_string();
-        }
-    }
-
-    "block".to_string()
-}
-
-/// Extract all image objects from the nested JSON structure
-pub fn extract_images(json: &serde_json::Value) -> Vec<ArmbianImage> {
-    let mut images = Vec::new();
-    extract_images_recursive(json, &mut images);
     images
 }
 
-fn extract_images_recursive(value: &serde_json::Value, images: &mut Vec<ArmbianImage>) {
-    match value {
-        serde_json::Value::Object(map) => {
-            if map.contains_key("board_slug") {
-                if let Ok(img) = serde_json::from_value::<ArmbianImage>(value.clone()) {
-                    if let Some(ref ext) = img.file_extension {
-                        if is_valid_image_file(ext, img.file_url.as_deref()) {
-                            let kernel = img.kernel_branch.as_deref().unwrap_or("");
-                            if kernel != "cloud" {
-                                images.push(img);
-                            }
-                        }
-                    }
-                }
-            }
-            for (_, v) in map {
-                extract_images_recursive(v, images);
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for v in arr {
-                extract_images_recursive(v, images);
-            }
-        }
-        _ => {}
+/// Map a single API image to a frontend-facing ImageInfo
+fn map_image(api: &ApiImage) -> ImageInfo {
+    ImageInfo {
+        release: api.release.clone(),
+        distro_release: api.distribution.clone(),
+        kernel_branch: api.kernel_branch.clone(),
+        kernel_version: api.kernel_version.clone(),
+        image_variant: api.variant.clone(),
+        preinstalled_application: api.application.clone().unwrap_or_default(),
+        promoted: api.promoted,
+        file_url: api.download.file_url.clone(),
+        direct_url: api.download.direct_url.clone(),
+        sha_url: api.download.sha_url.clone(),
+        file_size: api.download.size_bytes,
+        stability: api.stability.clone(),
+        format: api.format.clone(),
+        companions: api
+            .companions
+            .iter()
+            .map(|c| CompanionInfo {
+                type_name: c.type_name.clone(),
+                label: c.label.clone(),
+                url: c.url.clone(),
+                size_bytes: c.size_bytes,
+            })
+            .collect(),
+        display_variants: api
+            .display_variants
+            .iter()
+            .map(|dv| DisplayVariantInfo {
+                label: dv.label.clone(),
+                url: dv.url.clone(),
+                size_bytes: dv.size_bytes,
+            })
+            .collect(),
     }
-}
-
-/// Board data accumulated from images
-struct BoardData {
-    original_slug: String,
-    board_name: Option<String>,
-    vendor: Option<String>,
-    vendor_name: Option<String>,
-    vendor_logo: Option<String>,
-    count: usize,
-    /// board_support: "conf" without platinum
-    has_standard_support: bool,
-    /// board_support: "csc"
-    has_community_support: bool,
-    /// board_support: "eos" (end of support)
-    has_eos_support: bool,
-    /// board_support: "tvb" (TV Box - experimental)
-    has_tvb_support: bool,
-    /// board_support: "wip" (Work In Progress)
-    has_wip_support: bool,
-    /// board_support: "conf" with platinum: "true" and valid date
-    platinum_support_until: Option<String>,
-}
-
-/// Get unique board list from images
-pub fn get_unique_boards(images: &[ArmbianImage]) -> Vec<BoardInfo> {
-    let mut board_map: HashMap<String, BoardData> = HashMap::new();
-
-    for img in images {
-        if let Some(ref slug) = img.board_slug {
-            let normalized = normalize_slug(slug);
-            let entry = board_map.entry(normalized.clone()).or_insert(BoardData {
-                original_slug: slug.clone(),
-                board_name: img.board_name.clone(),
-                vendor: img.board_vendor.clone(),
-                vendor_name: img.company_name.clone(),
-                vendor_logo: img.company_logo.clone(),
-                count: 0,
-                has_standard_support: false,
-                has_community_support: false,
-                has_eos_support: false,
-                has_tvb_support: false,
-                has_wip_support: false,
-                platinum_support_until: None,
-            });
-            entry.count += 1;
-
-            // Use board_support field to determine support level
-            match img.board_support.as_deref() {
-                Some("conf") => {
-                    // conf can be either Platinum (if platinum=true) or Standard
-                    if img.platinum_support.as_deref() == Some("true") {
-                        if let Some(ref until) = img.platinum_support_until {
-                            entry.platinum_support_until = Some(until.clone());
-                        }
-                    } else {
-                        entry.has_standard_support = true;
-                    }
-                }
-                Some("csc") => entry.has_community_support = true,
-                Some("eos") => entry.has_eos_support = true,
-                Some("tvb") => entry.has_tvb_support = true,
-                Some("wip") => entry.has_wip_support = true,
-                _ => {}
-            }
-        }
-    }
-
-    let today = chrono::Utc::now().date_naive();
-
-    let mut boards: Vec<BoardInfo> = board_map
-        .into_iter()
-        .map(|(slug, data)| {
-            let name = data.board_name.unwrap_or(data.original_slug);
-
-            let has_platinum_support = data
-                .platinum_support_until
-                .as_ref()
-                .and_then(|until| chrono::NaiveDate::parse_from_str(until, "%Y-%m-%d").ok())
-                .map(|exp_date| exp_date >= today)
-                .unwrap_or(false);
-
-            let has_logo = data
-                .vendor_logo
-                .as_ref()
-                .map(|l| !l.is_empty())
-                .unwrap_or(false);
-            let (vendor_id, vendor_display, vendor_logo) = if has_logo {
-                let id = data.vendor.unwrap_or_else(|| "other".to_string());
-                let display = data
-                    .vendor_name
-                    .filter(|n| !n.is_empty())
-                    .unwrap_or_else(|| capitalize_vendor(&id));
-                (id, display, data.vendor_logo)
-            } else {
-                ("other".to_string(), "Other".to_string(), None)
-            };
-
-            // Community is shown only if no standard or platinum support
-            let has_community_support =
-                data.has_community_support && !data.has_standard_support && !has_platinum_support;
-
-            // EOS is shown only if no other support level
-            let has_eos_support = data.has_eos_support
-                && !data.has_standard_support
-                && !has_platinum_support
-                && !has_community_support;
-
-            // TVB is shown only if no other support level
-            let has_tvb_support = data.has_tvb_support
-                && !data.has_standard_support
-                && !has_platinum_support
-                && !has_community_support
-                && !has_eos_support;
-
-            // WIP is shown only if no other support level
-            let has_wip_support = data.has_wip_support
-                && !data.has_standard_support
-                && !has_platinum_support
-                && !has_community_support
-                && !has_eos_support
-                && !has_tvb_support;
-
-            BoardInfo {
-                slug,
-                name,
-                vendor: vendor_id,
-                vendor_name: vendor_display,
-                vendor_logo,
-                image_count: data.count,
-                has_standard_support: data.has_standard_support,
-                has_community_support,
-                has_platinum_support,
-                has_eos_support,
-                has_tvb_support,
-                has_wip_support,
-            }
-        })
-        .collect();
-
-    boards.sort_by(|a, b| {
-        // Platinum first, then Standard, then others
-        match (a.has_platinum_support, b.has_platinum_support) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => match (a.has_standard_support, b.has_standard_support) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-            },
-        }
-    });
-
-    // Log board statistics by support level
-    let platinum_count = boards.iter().filter(|b| b.has_platinum_support).count();
-    let standard_count = boards.iter().filter(|b| b.has_standard_support).count();
-    let community_count = boards.iter().filter(|b| b.has_community_support).count();
-    let eos_count = boards.iter().filter(|b| b.has_eos_support).count();
-    let tvb_count = boards.iter().filter(|b| b.has_tvb_support).count();
-    let wip_count = boards.iter().filter(|b| b.has_wip_support).count();
-
-    log_info!(
-        "images",
-        "Loaded {} boards: {} Platinum, {} Standard, {} Community, {} EOS, {} TVB, {} WIP",
-        boards.len(),
-        platinum_count,
-        standard_count,
-        community_count,
-        eos_count,
-        tvb_count,
-        wip_count
-    );
-    boards
-}
-
-/// Filter images for a specific board
-pub fn filter_images_for_board(
-    images: &[ArmbianImage],
-    board_slug: &str,
-    preapp_filter: Option<&str>,
-    kernel_filter: Option<&str>,
-    variant_filter: Option<&str>,
-    stable_only: bool,
-) -> Vec<ImageInfo> {
-    let normalized_board = normalize_slug(board_slug);
-
-    let mut filtered: Vec<ImageInfo> = images
-        .iter()
-        .filter(|img| {
-            let img_slug = img.board_slug.as_deref().unwrap_or("");
-            if normalize_slug(img_slug) != normalized_board {
-                return false;
-            }
-
-            if let Some(filter) = preapp_filter {
-                let preapp = img.preinstalled_application.as_deref().unwrap_or("");
-                if filter == config::images::EMPTY_FILTER {
-                    if !preapp.is_empty() {
-                        return false;
-                    }
-                } else if preapp != filter {
-                    return false;
-                }
-            }
-
-            if stable_only {
-                let repo = img.download_repository.as_deref().unwrap_or("");
-                if repo != config::images::STABLE_REPO {
-                    return false;
-                }
-            }
-
-            if let Some(filter) = kernel_filter {
-                let kernel = img.kernel_branch.as_deref().unwrap_or("");
-                if kernel != filter {
-                    return false;
-                }
-            }
-
-            if let Some(filter) = variant_filter {
-                let variant = img.image_variant.as_deref().unwrap_or("");
-                if variant != filter {
-                    return false;
-                }
-            }
-
-            true
-        })
-        .map(|img| ImageInfo {
-            armbian_version: img.armbian_version.clone().unwrap_or_default(),
-            distro_release: img.distro_release.clone().unwrap_or_default(),
-            kernel_branch: img.kernel_branch.clone().unwrap_or_default(),
-            kernel_version: img.kernel_version.clone().unwrap_or_default(),
-            image_variant: img.image_variant.clone().unwrap_or_default(),
-            preinstalled_application: img.preinstalled_application.clone().unwrap_or_default(),
-            promoted: img.promoted.as_deref() == Some("true"),
-            file_url: img.file_url.clone().unwrap_or_default(),
-            file_url_sha: img.file_url_sha.clone(),
-            file_size: img
-                .file_size
-                .as_ref()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0),
-            download_repository: img.download_repository.clone().unwrap_or_default(),
-            flash_method: determine_flash_method(img),
-        })
-        .collect();
-
-    filtered.sort_by(|a, b| match (a.promoted, b.promoted) {
-        (true, false) => std::cmp::Ordering::Less,
-        (false, true) => std::cmp::Ordering::Greater,
-        _ => b.armbian_version.cmp(&a.armbian_version),
-    });
-
-    filtered
 }

--- a/src-tauri/src/images/mod.rs
+++ b/src-tauri/src/images/mod.rs
@@ -1,128 +1,374 @@
 //! Image management module
 //!
-//! Handles fetching, parsing, and filtering Armbian image data.
-//! Caches the API response on disk for offline use.
+//! Handles fetching board, image, and vendor data from the Armbian REST API.
+//! Caches API responses on disk for offline use.
 
 mod filters;
 mod models;
 
-// Re-export types and functions
-pub use filters::{extract_images, filter_images_for_board, get_unique_boards};
-pub use models::{BoardInfo, ImageInfo};
-// ArmbianImage is used internally by filters module
+// Re-export types and mapper functions
+pub use filters::{map_board, map_images};
+pub use models::{ApiBoardSummary, ApiImage, ApiVendor, BoardInfo, ImageInfo};
+
+use models::ApiResponse;
 
 use crate::config;
 use crate::utils::get_cache_dir;
-use crate::{log_error, log_info, log_warn};
+use crate::{log_debug, log_error, log_warn};
 
-/// Path to the locally cached API response
-pub(crate) fn get_api_cache_path() -> std::path::PathBuf {
-    get_cache_dir(config::app::NAME)
-        .join("assets")
-        .join("api-images.json")
-}
+use once_cell::sync::Lazy;
+use reqwest::header::{HeaderMap, HeaderValue};
+use std::path::PathBuf;
 
-/// Fetch the all-images.json from Armbian, with local disk cache fallback.
+/// Shared HTTP client for JSON API endpoints (short timeout, X-Armbian-Client header)
 ///
-/// On success: saves the response to disk for offline use.
-/// On failure: loads the last saved response from disk.
-/// If both fail: returns an error.
-pub async fn fetch_all_images() -> Result<serde_json::Value, String> {
-    log_info!(
-        "images",
-        "Fetching all images from {}",
-        config::urls::ALL_IMAGES
+/// Uses SHORT_TIMEOUT_SECS (10s) since metadata responses are small. For large
+/// downloads (images) use a dedicated client with longer timeouts.
+static API_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        config::http::CLIENT_HEADER_NAME,
+        HeaderValue::from_static(config::http::CLIENT_HEADER_VALUE),
     );
 
-    // Try fetching from the API
-    match fetch_from_api().await {
-        Ok(json) => {
-            // Save to disk for offline use (non-blocking, best-effort)
-            save_api_cache(&json);
-            Ok(json)
-        }
-        Err(e) => {
-            log_warn!("images", "API fetch failed, trying local cache: {}", e);
-            load_api_cache().await
-        }
-    }
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .user_agent(config::app::USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(
+            config::http::CONNECT_TIMEOUT_SECS,
+        ))
+        .timeout(std::time::Duration::from_secs(
+            config::http::SHORT_TIMEOUT_SECS,
+        ))
+        .build()
+        .expect("Failed to create API HTTP client")
+});
+
+/// Safety cap on pagination to avoid runaway loops if the API returns
+/// inconsistent `meta.total` values.
+const MAX_PAGES: u32 = 50;
+
+/// Get the path for a named cache file inside the assets directory
+fn get_cache_path(name: &str) -> PathBuf {
+    get_cache_dir(config::app::NAME)
+        .join("assets")
+        .join(format!("{}.json", name))
 }
 
-/// Fetch the all-images.json directly from the remote Armbian API
+/// Save data to a cache file atomically (temp file + rename).
 ///
-/// Returns the parsed JSON on success, or an error string on network/parse failure.
-async fn fetch_from_api() -> Result<serde_json::Value, String> {
-    let response = reqwest::get(config::urls::ALL_IMAGES).await.map_err(|e| {
-        log_error!("images", "Failed to fetch images: {}", e);
-        format!("Failed to fetch images: {}", e)
-    })?;
-
-    let json: serde_json::Value = response.json().await.map_err(|e| {
-        log_error!("images", "Failed to parse JSON response: {}", e);
-        format!("Failed to parse JSON: {}", e)
-    })?;
-
-    log_info!("images", "Successfully fetched images data from API");
-    Ok(json)
+/// Uses `tokio::task::spawn_blocking` for consistency with the async runtime,
+/// and a unique tmp suffix to avoid collisions between concurrent writers.
+fn save_cache(name: &str, data: &str) {
+    let path = get_cache_path(name);
+    let data = data.to_string();
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        // Unique tmp filename per writer (nanosecond timestamp + pid) to avoid
+        // races if two tasks save the same cache file concurrently.
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp_path = path.with_extension(format!("json.{}.{}.tmp", pid, nanos));
+        if let Err(e) = std::fs::write(&tmp_path, &data) {
+            log_warn!("images", "Failed to write cache temp file: {}", e);
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, &path) {
+            log_warn!("images", "Failed to rename cache file: {}", e);
+            let _ = std::fs::remove_file(&tmp_path);
+        } else {
+            log_debug!("images", "Saved cache to {}", path.display());
+        }
+    });
 }
 
-/// Save API response to disk for offline use
-///
-/// Serializes the JSON and writes it on a blocking thread to avoid
-/// stalling the Tokio async runtime with synchronous file I/O.
-/// Uses a temp file + rename pattern for atomic writes to prevent
-/// partial reads if the app crashes mid-write.
-fn save_api_cache(json: &serde_json::Value) {
-    let path = get_api_cache_path();
-    match serde_json::to_string(json) {
-        Ok(data) => {
-            std::thread::spawn(move || {
-                if let Some(parent) = path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                // Write to temp file first, then rename for atomicity
-                let tmp_path = path.with_extension("json.tmp");
-                if let Err(e) = std::fs::write(&tmp_path, &data) {
-                    log_warn!("images", "Failed to write API cache temp file: {}", e);
-                    return;
-                }
-                if let Err(e) = std::fs::rename(&tmp_path, &path) {
-                    log_warn!("images", "Failed to rename API cache file: {}", e);
-                    let _ = std::fs::remove_file(&tmp_path);
-                } else {
-                    log_info!("images", "Saved API cache to {}", path.display());
-                }
-            });
-        }
-        Err(e) => {
-            log_warn!("images", "Failed to serialize API cache: {}", e);
-        }
-    }
-}
-
-/// Load API response from disk cache
-///
-/// Uses async I/O to avoid blocking the Tokio runtime.
-async fn load_api_cache() -> Result<serde_json::Value, String> {
-    let path = get_api_cache_path();
+/// Load data from a cache file
+async fn load_cache(name: &str) -> Result<String, String> {
+    let path = get_cache_path(name);
     if !path.exists() {
-        return Err("No cached API data available (first launch while offline)".to_string());
+        return Err(format!(
+            "No cached {} data available (first launch while offline)",
+            name
+        ));
     }
 
     let data = tokio::fs::read_to_string(&path).await.map_err(|e| {
-        log_error!("images", "Failed to read API cache: {}", e);
+        log_error!("images", "Failed to read {} cache: {}", name, e);
         format!("Failed to read cached data: {}", e)
     })?;
 
-    let json: serde_json::Value = serde_json::from_str(&data).map_err(|e| {
-        log_error!("images", "Failed to parse API cache: {}", e);
-        format!("Failed to parse cached data: {}", e)
-    })?;
-
-    log_info!(
+    log_debug!(
         "images",
-        "Loaded API data from local cache ({})",
+        "Loaded {} data from local cache ({})",
+        name,
         path.display()
     );
-    Ok(json)
+    Ok(data)
+}
+
+/// Delete old API cache file from pre-migration format
+pub fn cleanup_legacy_cache() {
+    let legacy_path = get_cache_dir(config::app::NAME)
+        .join("assets")
+        .join("api-images.json");
+    if legacy_path.exists() {
+        match std::fs::remove_file(&legacy_path) {
+            Ok(_) => log_debug!(
+                "images",
+                "Removed legacy api-images.json cache: {}",
+                legacy_path.display()
+            ),
+            Err(e) => log_warn!("images", "Failed to remove legacy cache: {}", e),
+        }
+    }
+}
+
+/// Fetch all boards from the Armbian REST API with pagination support.
+///
+/// Requests up to 500 boards per page and fetches additional pages if needed.
+/// On success, saves the response to disk for offline use.
+/// On failure, falls back to the local disk cache.
+pub async fn fetch_boards() -> Result<Vec<ApiBoardSummary>, String> {
+    log_debug!(
+        "images",
+        "Fetching boards from {}/boards",
+        config::urls::API_BASE
+    );
+
+    match fetch_boards_from_api().await {
+        Ok(boards) => {
+            // Save to disk cache
+            if let Ok(json) = serde_json::to_string(&boards) {
+                save_cache("api-boards", &json);
+            }
+            Ok(boards)
+        }
+        Err(e) => {
+            log_warn!("images", "API fetch failed, trying local cache: {}", e);
+            let data = load_cache("api-boards").await?;
+            serde_json::from_str(&data).map_err(|e| {
+                log_error!("images", "Failed to parse boards cache: {}", e);
+                format!("Failed to parse cached boards: {}", e)
+            })
+        }
+    }
+}
+
+/// Fetch boards directly from the remote API, handling pagination.
+///
+/// Safety guards:
+/// - Breaks early if the API returns an empty page (prevents infinite loops
+///   when `meta.total` is inconsistent with actual data length).
+/// - Enforces a hard `MAX_PAGES` cap as a final safety net.
+async fn fetch_boards_from_api() -> Result<Vec<ApiBoardSummary>, String> {
+    let url_base = format!("{}/boards", config::urls::API_BASE);
+    let mut all_boards = Vec::new();
+    let mut page: u32 = 1;
+    let limit: u32 = 500;
+
+    while page <= MAX_PAGES {
+        let response: ApiResponse<Vec<ApiBoardSummary>> = API_CLIENT
+            .get(&url_base)
+            .query(&[("limit", limit.to_string()), ("page", page.to_string())])
+            .send()
+            .await
+            .map_err(|e| format!("Failed to fetch boards: {}", e))?
+            .error_for_status()
+            .map_err(|e| format!("Boards API returned error: {}", e))?
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse boards response: {}", e))?;
+
+        // Guard against runaway loops: stop immediately on empty page
+        if response.data.is_empty() {
+            break;
+        }
+
+        let total = response.meta.total.unwrap_or(0);
+        all_boards.extend(response.data);
+
+        // Stop when we've fetched enough to cover the advertised total
+        if (page * limit) >= total {
+            break;
+        }
+        page += 1;
+    }
+
+    if page > MAX_PAGES {
+        log_warn!(
+            "images",
+            "Boards pagination reached MAX_PAGES cap ({}); stopping early",
+            MAX_PAGES
+        );
+    }
+
+    // Breakdown of support tiers for diagnostic purposes
+    let mut platinum = 0u32;
+    let mut standard = 0u32;
+    let mut community = 0u32;
+    let mut eos = 0u32;
+    let mut other = 0u32;
+    for b in &all_boards {
+        match b.support_tier.as_str() {
+            "platinum" => platinum += 1,
+            "standard" => standard += 1,
+            "community" => community += 1,
+            "eos" => eos += 1,
+            _ => other += 1,
+        }
+    }
+
+    log_debug!(
+        "images",
+        "Successfully fetched {} boards from API (platinum: {}, standard: {}, community: {}, eos: {}, other: {})",
+        all_boards.len(),
+        platinum,
+        standard,
+        community,
+        eos,
+        other
+    );
+    Ok(all_boards)
+}
+
+/// Fetch images for a specific board from the Armbian REST API.
+///
+/// Supports optional query parameter filters passed directly to the API.
+/// On success, saves the response to disk for offline use.
+/// On failure, falls back to the local disk cache.
+pub async fn fetch_images_for_board(
+    slug: &str,
+    variant: Option<&str>,
+    distribution: Option<&str>,
+    branch: Option<&str>,
+    promoted: Option<bool>,
+) -> Result<Vec<ApiImage>, String> {
+    log_debug!("images", "Fetching images for board: {} from API", slug);
+
+    let cache_name = format!("api-images-{}", slug);
+
+    match fetch_images_from_api(slug, variant, distribution, branch, promoted).await {
+        Ok(images) => {
+            if let Ok(json) = serde_json::to_string(&images) {
+                save_cache(&cache_name, &json);
+            }
+            Ok(images)
+        }
+        Err(e) => {
+            log_warn!(
+                "images",
+                "API fetch for board {} failed, trying cache: {}",
+                slug,
+                e
+            );
+            let data = load_cache(&cache_name).await?;
+            serde_json::from_str(&data).map_err(|e| {
+                log_error!("images", "Failed to parse images cache for {}: {}", slug, e);
+                format!("Failed to parse cached images: {}", e)
+            })
+        }
+    }
+}
+
+/// Fetch images for a board directly from the remote API
+async fn fetch_images_from_api(
+    slug: &str,
+    variant: Option<&str>,
+    distribution: Option<&str>,
+    branch: Option<&str>,
+    promoted: Option<bool>,
+) -> Result<Vec<ApiImage>, String> {
+    let url = format!("{}/boards/{}/images", config::urls::API_BASE, slug);
+
+    // Build query parameters using reqwest's encoder (handles URL-encoding)
+    let mut params: Vec<(&str, String)> = Vec::new();
+    if let Some(v) = variant {
+        params.push(("variant", v.to_string()));
+    }
+    if let Some(d) = distribution {
+        params.push(("distribution", d.to_string()));
+    }
+    if let Some(b) = branch {
+        params.push(("branch", b.to_string()));
+    }
+    if let Some(p) = promoted {
+        params.push(("promoted", p.to_string()));
+    }
+
+    let response: ApiResponse<Vec<ApiImage>> = API_CLIENT
+        .get(&url)
+        .query(&params)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch images for {}: {}", slug, e))?
+        .error_for_status()
+        .map_err(|e| format!("Images API returned error for {}: {}", slug, e))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse images response for {}: {}", slug, e))?;
+
+    log_debug!(
+        "images",
+        "Successfully fetched {} images for board {}",
+        response.data.len(),
+        slug
+    );
+    Ok(response.data)
+}
+
+/// Fetch all vendors from the Armbian REST API.
+///
+/// On success, saves the response to disk for offline use.
+/// On failure, falls back to the local disk cache.
+pub async fn fetch_vendors() -> Result<Vec<ApiVendor>, String> {
+    log_debug!(
+        "images",
+        "Fetching vendors from {}/vendors",
+        config::urls::API_BASE
+    );
+
+    match fetch_vendors_from_api().await {
+        Ok(vendors) => {
+            if let Ok(json) = serde_json::to_string(&vendors) {
+                save_cache("api-vendors", &json);
+            }
+            Ok(vendors)
+        }
+        Err(e) => {
+            log_warn!("images", "Vendors API fetch failed, trying cache: {}", e);
+            let data = load_cache("api-vendors").await?;
+            serde_json::from_str(&data).map_err(|e| {
+                log_error!("images", "Failed to parse vendors cache: {}", e);
+                format!("Failed to parse cached vendors: {}", e)
+            })
+        }
+    }
+}
+
+/// Fetch vendors directly from the remote API
+async fn fetch_vendors_from_api() -> Result<Vec<ApiVendor>, String> {
+    let url = format!("{}/vendors", config::urls::API_BASE);
+
+    let response: ApiResponse<Vec<ApiVendor>> = API_CLIENT
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch vendors: {}", e))?
+        .error_for_status()
+        .map_err(|e| format!("Vendors API returned error: {}", e))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse vendors response: {}", e))?;
+
+    log_debug!(
+        "images",
+        "Successfully fetched {} vendors from API",
+        response.data.len()
+    );
+    Ok(response.data)
 }

--- a/src-tauri/src/images/models.rs
+++ b/src-tauri/src/images/models.rs
@@ -1,73 +1,147 @@
 //! Image data models
 //!
-//! Types representing Armbian images and boards.
+//! Types representing Armbian API responses, boards, images, and vendors.
 
 use serde::{Deserialize, Serialize};
 
-/// Raw Armbian image data from the API
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ArmbianImage {
-    pub board_slug: Option<String>,
-    pub board_name: Option<String>,
-    pub board_vendor: Option<String>,
-    pub company_name: Option<String>,
-    pub company_logo: Option<String>,
-    pub armbian_version: Option<String>,
-    /// API field: "distro"
-    #[serde(alias = "distro")]
-    pub distro_release: Option<String>,
-    /// API field: "branch"
-    #[serde(alias = "branch")]
-    pub kernel_branch: Option<String>,
-    /// API field: "kernel_version"
-    #[serde(alias = "kernel_version")]
-    pub kernel_version: Option<String>,
-    /// API field: "variant"
-    #[serde(alias = "variant")]
-    pub image_variant: Option<String>,
-    /// API field: "file_application"
-    #[serde(alias = "file_application")]
-    pub preinstalled_application: Option<String>,
-    pub promoted: Option<String>,
-    pub file_url: Option<String>,
-    pub file_url_sha: Option<String>,
-    pub file_extension: Option<String>,
-    pub file_size: Option<String>,
-    pub download_repository: Option<String>,
-    pub redi_url: Option<String>,
-    /// API field: "platinum"
-    #[serde(alias = "platinum")]
-    pub platinum_support: Option<String>,
-    /// API field: "platinum_until"
-    #[serde(alias = "platinum_until")]
-    pub platinum_support_until: Option<String>,
-    /// Board support level: "conf", "csc", "eos", "tvb", "wip"
-    pub board_support: Option<String>,
-    /// Flash method: "block" (default SD/USB), "qdl" (Qualcomm EDL)
-    pub flash_method: Option<String>,
+// ─── API response envelope ───────────────────────────────────────────────────
+
+/// Generic API response envelope wrapping data + metadata
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiResponse<T> {
+    pub data: T,
+    #[serde(default)]
+    pub meta: ApiMeta,
 }
 
-/// Board information for display
+/// Metadata attached to every API response
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub struct ApiMeta {
+    pub last_sync: Option<String>,
+    pub total: Option<u32>,
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+// ─── API types: Boards ───────────────────────────────────────────────────────
+
+/// Board summary from `GET /boards`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiBoardSummary {
+    pub slug: String,
+    pub name: String,
+    pub vendor_slug: String,
+    pub vendor_name: String,
+    pub support_tier: String,
+    pub image_count: u32,
+    pub has_desktop: bool,
+    pub promoted: bool,
+    pub image_url: Option<String>,
+    pub soc: Option<String>,
+    pub architecture: Option<String>,
+    pub summary: Option<String>,
+}
+
+// ─── API types: Images ───────────────────────────────────────────────────────
+
+/// Image entry from `GET /boards/:slug/images`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiImage {
+    pub id: String,
+    pub board_slug: String,
+    pub variant: String,
+    pub distribution: String,
+    pub release: String,
+    pub kernel_branch: String,
+    pub kernel_version: String,
+    pub application: Option<String>,
+    pub promoted: bool,
+    pub stability: String,
+    pub format: String,
+    pub storage: Option<String>,
+    #[serde(default)]
+    pub companions: Vec<ApiCompanion>,
+    #[serde(default)]
+    pub display_variants: Vec<ApiDisplayVariant>,
+    pub download: ApiDownloadInfo,
+}
+
+/// Download metadata nested inside an image entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiDownloadInfo {
+    pub file_url: String,
+    pub direct_url: String,
+    pub sha_url: Option<String>,
+    pub asc_url: Option<String>,
+    pub torrent_url: Option<String>,
+    pub size_bytes: u64,
+    pub updated_at: Option<String>,
+}
+
+/// Companion file required for flashing (bootloader, fip, recovery, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiCompanion {
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub label: String,
+    pub url: String,
+    pub size_bytes: u64,
+}
+
+/// Display variant for multi-panel devices
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiDisplayVariant {
+    pub label: String,
+    pub url: String,
+    pub size_bytes: u64,
+}
+
+// ─── API types: Vendors ──────────────────────────────────────────────────────
+
+/// Vendor/manufacturer from `GET /vendors`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiVendor {
+    pub slug: String,
+    pub name: String,
+    pub logo_url: Option<String>,
+    pub website: Option<String>,
+    pub description: Option<String>,
+    pub board_count: u32,
+    pub partner_tier: Option<String>,
+}
+
+// ─── Frontend-facing types ───────────────────────────────────────────────────
+
+/// Board information for display in the frontend
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BoardInfo {
     pub slug: String,
     pub name: String,
+    /// Vendor slug identifier (e.g., "radxa")
     pub vendor: String,
+    /// Vendor display name (e.g., "Radxa")
     pub vendor_name: String,
-    pub vendor_logo: Option<String>,
+    /// Support tier: "platinum", "standard", "community", "eos", "tvb", "wip"
+    pub support_tier: String,
     pub image_count: usize,
-    pub has_standard_support: bool,
-    pub has_community_support: bool,
-    pub has_platinum_support: bool,
-    pub has_eos_support: bool,
-    pub has_tvb_support: bool,
-    pub has_wip_support: bool,
+    /// Whether desktop environment images are available
+    pub has_desktop: bool,
+    /// Whether this board is featured/promoted
+    pub promoted: bool,
+    /// System-on-Chip model (e.g., "RK3588")
+    pub soc: Option<String>,
+    /// CPU architecture (e.g., "arm64")
+    pub architecture: Option<String>,
+    /// Short board description
+    pub summary: Option<String>,
 }
 
 /// Processed image information for the UI
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageInfo {
-    pub armbian_version: String,
+    /// Armbian release version (e.g., "24.02.0")
+    pub release: String,
     pub distro_release: String,
     pub kernel_branch: String,
     pub kernel_version: String,
@@ -75,9 +149,37 @@ pub struct ImageInfo {
     pub preinstalled_application: String,
     pub promoted: bool,
     pub file_url: String,
-    pub file_url_sha: Option<String>,
+    /// Direct CDN download URL
+    pub direct_url: String,
+    /// SHA256 checksum file URL
+    pub sha_url: Option<String>,
+    /// Compressed image size in bytes
     pub file_size: u64,
-    pub download_repository: String,
-    /// Flash method: "block" (default) or "qdl" (Qualcomm EDL)
-    pub flash_method: String,
+    /// Stability level: "stable", "edge", "nightly"
+    pub stability: String,
+    /// Image format: "sd" (block), "qdl" (Qualcomm EDL), "rootfs", "qemu", "hyperv"
+    pub format: String,
+    /// Companion files (bootloaders, firmware, etc.)
+    #[serde(default)]
+    pub companions: Vec<CompanionInfo>,
+    /// Display variant files for multi-panel devices
+    #[serde(default)]
+    pub display_variants: Vec<DisplayVariantInfo>,
+}
+
+/// Companion file info for the frontend
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompanionInfo {
+    pub type_name: String,
+    pub label: String,
+    pub url: String,
+    pub size_bytes: u64,
+}
+
+/// Display variant info for the frontend
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DisplayVariantInfo {
+    pub label: String,
+    pub url: String,
+    pub size_bytes: u64,
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,12 +118,15 @@ fn main() {
         std::env::consts::ARCH
     );
     log_info!("main", "Config URLs:");
-    log_info!("main", "  - Images API: {}", config::urls::ALL_IMAGES);
+    log_info!("main", "  - API Base: {}", config::urls::API_BASE);
     log_info!(
         "main",
         "  - Board images: {}",
         config::urls::BOARD_IMAGES_BASE
     );
+
+    // Remove legacy api-images.json cache from pre-migration format
+    images::cleanup_legacy_cache();
 
     // Clean up orphaned custom decompressed images from previous sessions
     // (Cache management is done in setup with access to settings)
@@ -154,6 +157,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::board_queries::get_boards,
             commands::board_queries::get_images_for_board,
+            commands::board_queries::get_vendors,
             commands::board_queries::get_block_devices,
             commands::scraping::get_cached_board_image,
             commands::scraping::get_cached_vendor_logo,

--- a/src-tauri/src/picture_cache.rs
+++ b/src-tauri/src/picture_cache.rs
@@ -402,134 +402,37 @@ pub async fn read_as_data_uri(path: &Path) -> Option<String> {
     }
 }
 
-/// Read the cached API JSON from disk (same path used by `images::fetch_all_images`)
-///
-/// Returns `Some(json_text)` if the file exists and can be read, `None` otherwise.
-fn read_api_cache_from_disk() -> Option<String> {
-    let path = crate::images::get_api_cache_path();
-    if !path.exists() {
-        return None;
-    }
-    match std::fs::read_to_string(&path) {
-        Ok(text) => Some(text),
-        Err(e) => {
-            log_warn!(MODULE, "Failed to read local API cache: {}", e);
-            None
-        }
-    }
-}
-
-/// Fetch the API JSON from the remote server (fallback for prepopulate)
-async fn fetch_api_for_prepopulate() -> Option<String> {
-    use std::time::Duration;
-
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            log_warn!(MODULE, "Failed to build HTTP client for prepopulate: {}", e);
-            return None;
-        }
-    };
-
-    let response = match client.get(config::urls::ALL_IMAGES).send().await {
-        Ok(r) if r.status().is_success() => r,
-        Ok(r) => {
-            log_warn!(
-                MODULE,
-                "API returned {} during prepopulate, skipping",
-                r.status()
-            );
-            return None;
-        }
-        Err(e) => {
-            log_info!(MODULE, "Cannot reach API for prepopulate (offline?): {}", e);
-            return None;
-        }
-    };
-
-    match response.text().await {
-        Ok(t) => Some(t),
-        Err(e) => {
-            log_warn!(MODULE, "Failed to read API response: {}", e);
-            None
-        }
-    }
-}
-
 /// Pre-populate the asset cache by downloading all board images and vendor logos
 ///
-/// Reads the board list from the local API cache on disk (populated by
-/// `images::fetch_all_images`). Falls back to fetching from the remote API
-/// if the local cache is missing. Uses a semaphore to limit concurrency.
+/// Fetches board and vendor lists from the Armbian REST API (with disk cache fallback),
+/// then downloads images and logos using a semaphore to limit concurrency.
 /// Intended to be called once at app startup in the background.
 pub async fn prepopulate_assets() {
     log_info!(MODULE, "Pre-populating asset cache...");
 
-    // Try reading the locally cached API response first (avoids duplicate HTTP request)
-    let json_text = match read_api_cache_from_disk() {
-        Some(text) => {
-            log_info!(MODULE, "Using local API cache for prepopulate");
-            text
-        }
-        None => {
-            // Fallback: fetch from API if local cache is not available yet
-            log_info!(
-                MODULE,
-                "No local API cache, fetching from API for prepopulate"
-            );
-            match fetch_api_for_prepopulate().await {
-                Some(text) => text,
-                None => return,
-            }
+    // Fetch boards and vendors from API (with disk cache fallback)
+    let boards = match crate::images::fetch_boards().await {
+        Ok(b) => b,
+        Err(e) => {
+            log_warn!(MODULE, "Cannot fetch boards for prepopulate: {}", e);
+            return;
         }
     };
 
-    // Parse to extract board slugs and vendor logos
-    // API returns { "assets": [...] }
-    let root: serde_json::Value = match serde_json::from_str(&json_text) {
+    let vendors = match crate::images::fetch_vendors().await {
         Ok(v) => v,
         Err(e) => {
-            log_warn!(MODULE, "Failed to parse API JSON: {}", e);
-            return;
-        }
-    };
-    let images = match root.get("assets").and_then(|v| v.as_array()) {
-        Some(arr) => arr,
-        None => {
-            log_warn!(MODULE, "API JSON missing 'assets' array");
-            return;
+            log_warn!(MODULE, "Cannot fetch vendors for prepopulate: {}", e);
+            Vec::new() // Continue with board images even if vendors fail
         }
     };
 
-    // Collect unique board slugs and vendor logos
-    let mut board_slugs = std::collections::HashSet::new();
-    let mut vendor_logos: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-
-    for image in images {
-        if let Some(slug) = image.get("board_slug").and_then(|v| v.as_str()) {
-            board_slugs.insert(slug.to_string());
-        }
-        if let Some(vendor) = image.get("board_vendor").and_then(|v| v.as_str()) {
-            if let Some(logo) = image.get("company_logo").and_then(|v| v.as_str()) {
-                if !logo.is_empty() && !vendor.is_empty() {
-                    vendor_logos
-                        .entry(vendor.to_string())
-                        .or_insert_with(|| logo.to_string());
-                }
-            }
-        }
-    }
-
-    let total = board_slugs.len() + vendor_logos.len();
-    log_info!(
+    let total = boards.len() + vendors.len();
+    log_debug!(
         MODULE,
         "Pre-populating {} board images + {} vendor logos ({} total)",
-        board_slugs.len(),
-        vendor_logos.len(),
+        boards.len(),
+        vendors.len(),
         total
     );
 
@@ -537,8 +440,9 @@ pub async fn prepopulate_assets() {
     let mut handles = Vec::new();
 
     // Download board images
-    for slug in board_slugs {
+    for board in &boards {
         let sem = semaphore.clone();
+        let slug = board.slug.clone();
         handles.push(tokio::spawn(async move {
             let _permit = match sem.acquire().await {
                 Ok(p) => p,
@@ -555,14 +459,16 @@ pub async fn prepopulate_assets() {
     }
 
     // Download vendor logos
-    for (vendor_id, logo_url) in vendor_logos {
+    for vendor in &vendors {
         let sem = semaphore.clone();
+        let slug = vendor.slug.clone();
         handles.push(tokio::spawn(async move {
             let _permit = match sem.acquire().await {
                 Ok(p) => p,
                 Err(_) => return,
             };
-            get_asset("vendors", &vendor_id, &logo_url).await;
+            let url = format!("{}{}.png", config::urls::VENDOR_IMAGES_BASE, slug);
+            get_asset("vendors", &slug, &url).await;
         }));
     }
 
@@ -607,7 +513,7 @@ pub async fn refresh_stale_assets() {
         return;
     }
 
-    log_info!(
+    log_debug!(
         MODULE,
         "Refreshing {} stale assets (of {} total)",
         stale_entries.len(),
@@ -641,18 +547,18 @@ pub async fn refresh_stale_assets() {
                 return;
             }
 
-            // Use stored URL if available, otherwise reconstruct for boards
-            let url = match &entry.url {
-                Some(u) => u.clone(),
-                None => match kind {
-                    "boards" => format!(
-                        "{}{}/{}.png",
-                        config::urls::BOARD_IMAGES_BASE,
-                        config::urls::BOARD_IMAGE_SIZE,
-                        asset_key
-                    ),
-                    // Legacy entries without URL cannot be refreshed
-                    _ => return,
+            // Reconstruct URL from kind and asset key
+            let url = match kind {
+                "boards" => format!(
+                    "{}{}/{}.png",
+                    config::urls::BOARD_IMAGES_BASE,
+                    config::urls::BOARD_IMAGE_SIZE,
+                    asset_key
+                ),
+                "vendors" => format!("{}{}.png", config::urls::VENDOR_IMAGES_BASE, asset_key),
+                _ => match &entry.url {
+                    Some(u) => u.clone(),
+                    None => return,
                 },
             };
 
@@ -675,7 +581,7 @@ pub async fn refresh_stale_assets() {
         }
     }
 
-    log_info!(
+    log_debug!(
         MODULE,
         "Background refresh complete: {} assets processed",
         processed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,7 +218,7 @@ function AppContent() {
 
       // Create ImageInfo for the cached image (same pattern as handleCustomImage)
       const cachedImage: ImageInfo = {
-        armbian_version: 'Cached',
+        release: 'Cached',
         distro_release: filename,
         kernel_branch: '',
         kernel_version: '',
@@ -226,10 +226,13 @@ function AppContent() {
         preinstalled_application: '',
         promoted: false,
         file_url: '',
-        file_url_sha: null,
+        direct_url: '',
+        sha_url: null,
         file_size: size,
-        download_repository: 'cache',
-        flash_method: 'block',
+        stability: 'stable',
+        format: 'sd',
+        companions: [],
+        display_variants: [],
         is_custom: true,
         custom_path: imagePath,
       };
@@ -246,14 +249,10 @@ function AppContent() {
         name: boardName || t('custom.customImage'),
         vendor: hasCacheMetadata ? 'detected' : 'cached',
         vendor_name: hasCacheMetadata ? (boardName || 'Unknown') : 'Cached',
-        vendor_logo: null,
+        support_tier: 'community',
         image_count: 1,
-        has_standard_support: false,
-        has_community_support: false,
-        has_platinum_support: false,
-        has_eos_support: false,
-        has_tvb_support: false,
-        has_wip_support: false,
+        has_desktop: false,
+        promoted: false,
       };
 
       setSelectedManufacturer({
@@ -339,7 +338,7 @@ function AppContent() {
 
         // Create a custom ImageInfo object
         const customImage: ImageInfo = {
-          armbian_version: 'Custom',
+          release: 'Custom',
           distro_release: result.name,
           kernel_branch: '',
           kernel_version: '',
@@ -347,10 +346,13 @@ function AppContent() {
           preinstalled_application: '',
           promoted: false,
           file_url: '',
-          file_url_sha: null,
+          direct_url: '',
+          sha_url: null,
           file_size: result.size,
-          download_repository: 'local',
-          flash_method: flashMethod,
+          stability: 'stable',
+          format: flashMethod,
+          companions: [],
+          display_variants: [],
           is_custom: true,
           custom_path: result.path,
         };
@@ -364,14 +366,10 @@ function AppContent() {
           name: t('custom.customImage'),
           vendor: 'custom',
           vendor_name: 'Custom',
-          vendor_logo: null,
+          support_tier: 'community',
           image_count: 1,
-          has_standard_support: false,
-          has_community_support: false,
-          has_platinum_support: false,
-          has_eos_support: false,
-          has_tvb_support: false,
-          has_wip_support: false,
+          has_desktop: false,
+          promoted: false,
         };
 
         // Set manufacturer for display consistency (same pattern as cached image reuse)
@@ -505,7 +503,7 @@ function AppContent() {
         isOpen={activeModal === 'device'}
         onClose={() => setActiveModal('none')}
         onSelect={handleDeviceSelect}
-        flashMethod={selectedImage?.flash_method}
+        flashMethod={selectedImage?.format}
       />
 
       {/* Armbian board detection modal */}

--- a/src/components/flash/FlashProgress.tsx
+++ b/src/components/flash/FlashProgress.tsx
@@ -53,7 +53,7 @@ export function FlashProgress({
     if (image.is_custom) {
       return image.distro_release;
     }
-    return `Armbian ${image.armbian_version} ${image.distro_release}`;
+    return `Armbian ${image.release} ${image.distro_release}`;
   }
 
   /** Stages that show an indeterminate (animated) progress bar instead of a percentage */
@@ -140,7 +140,7 @@ export function FlashProgress({
 
         {stage === 'complete' && (
           <p className="flash-success-hint">
-            {image.flash_method === 'qdl'
+            {image.format === 'qdl'
               ? t('flash.successHintQdl')
               : image.is_custom
                 ? t('flash.successHintCustom')

--- a/src/components/modals/ImageModal.tsx
+++ b/src/components/modals/ImageModal.tsx
@@ -34,10 +34,10 @@ interface ImageModalProps {
 const IMAGE_FILTER_PREDICATES: Record<Exclude<ImageFilterType, 'all'>, (img: ImageInfo) => boolean> = {
   // Recommended: promoted images
   recommended: (img) => img.promoted === true,
-  // Stable: from archive repository and not trunk version
-  stable: (img) => img.download_repository === 'archive' && !img.armbian_version.includes('trunk'),
-  // Nightly: trunk versions
-  nightly: (img) => img.armbian_version.includes('trunk'),
+  // Stable: stability field is "stable"
+  stable: (img) => img.stability === 'stable',
+  // Nightly: stability field is "nightly"
+  nightly: (img) => img.stability === 'nightly',
   // Apps: has preinstalled application
   apps: (img) => !!(img.preinstalled_application && img.preinstalled_application.length > 0),
   // Barebone/Minimal: no desktop environment and no preinstalled apps
@@ -91,7 +91,7 @@ export function ImageModal({ isOpen, onClose, onSelect, board }: ImageModalProps
   // Use hook for async data fetching
   const { data: allImages, loading, error, reload } = useAsyncDataWhen<ImageInfo[]>(
     isOpen && !!board,
-    () => getImagesForBoard(board!.slug, undefined, undefined, undefined, false),
+    () => getImagesForBoard(board!.slug),
     [isOpen, board?.slug]
   );
 
@@ -117,8 +117,8 @@ export function ImageModal({ isOpen, onClose, onSelect, board }: ImageModalProps
    */
   function handleImageClick(image: ImageInfo) {
     // Check if warning is needed
-    const isNightly = image.armbian_version.includes('trunk');
-    const isCommunityBoard = board?.has_community_support === true;
+    const isNightly = image.stability === 'nightly';
+    const isCommunityBoard = board?.support_tier === 'community';
 
     // No warning for custom images or stable images on supported boards
     if (!isNightly && !isCommunityBoard) {
@@ -236,7 +236,7 @@ export function ImageModal({ isOpen, onClose, onSelect, board }: ImageModalProps
 
                 <div className="list-item-content" style={{ flex: 1 }}>
                   <div className="list-item-title">
-                    Armbian {image.armbian_version} {image.distro_release}
+                    Armbian {image.release} {image.distro_release}
                   </div>
 
                   {/* Side panel with main info */}
@@ -326,7 +326,7 @@ export function ImageModal({ isOpen, onClose, onSelect, board }: ImageModalProps
           isOpen={showUnstableWarning}
           title={t('modal.imageStatusTitle')}
           message={
-            board?.has_community_support === true
+            board?.support_tier === 'community'
               ? t('modal.communityBoardMessage')
               : t('modal.nightlyBuildMessage')
           }

--- a/src/components/shared/BoardBadges.tsx
+++ b/src/components/shared/BoardBadges.tsx
@@ -16,37 +16,37 @@ interface BoardBadgesProps {
 export function BoardBadges({ board, className = '' }: BoardBadgesProps) {
   return (
     <div className={`board-grid-badges ${className}`}>
-      {board.has_platinum_support && (
+      {board.support_tier === 'platinum' && (
         <span className="badge-platinum">
           <Crown size={10} />
           <span>Platinum</span>
         </span>
       )}
-      {board.has_standard_support && !board.has_platinum_support && (
+      {board.support_tier === 'standard' && (
         <span className="badge-standard">
           <Shield size={10} />
           <span>Standard</span>
         </span>
       )}
-      {board.has_community_support && (
+      {board.support_tier === 'community' && (
         <span className="badge-community">
           <Users size={10} />
           <span>Community</span>
         </span>
       )}
-      {board.has_eos_support && (
+      {board.support_tier === 'eos' && (
         <span className="badge-eos">
           <Clock size={10} />
           <span>EOS</span>
         </span>
       )}
-      {board.has_tvb_support && (
+      {board.support_tier === 'tvb' && (
         <span className="badge-tvb">
           <Tv size={10} />
           <span>TV Box</span>
         </span>
       )}
-      {board.has_wip_support && (
+      {board.support_tier === 'wip' && (
         <span className="badge-wip">
           <Wrench size={10} />
           <span>WIP</span>

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -130,7 +130,7 @@ export function useFlashOperation({
   }, []);
 
   /** Whether the current image uses QDL (Qualcomm EDL) flashing */
-  const isQdlMode = image.flash_method === 'qdl';
+  const isQdlMode = image.format === 'qdl';
 
   /**
    * Check device connection and trigger disconnect handler if missing
@@ -275,7 +275,7 @@ export function useFlashOperation({
     }, POLLING.DOWNLOAD_PROGRESS);
 
     try {
-      const path = await downloadImage(image.file_url, image.file_url_sha);
+      const path = await downloadImage(image.file_url, image.sha_url);
       setImagePath(path);
       if (intervalRef.current) clearInterval(intervalRef.current);
       startFlash(path);

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, ArmbianReleaseInfo, CachedImageInfo, QdlDevice } from '../types';
+import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, ArmbianReleaseInfo, CachedImageInfo, QdlDevice, VendorInfo } from '../types';
 
 export async function getBoards(): Promise<BoardInfo[]> {
   return invoke('get_boards');
@@ -10,15 +10,19 @@ export async function getImagesForBoard(
   preappFilter?: string,
   kernelFilter?: string,
   variantFilter?: string,
-  stableOnly: boolean = false
+  stability?: string
 ): Promise<ImageInfo[]> {
   return invoke('get_images_for_board', {
     boardSlug,
     preappFilter,
     kernelFilter,
     variantFilter,
-    stableOnly,
+    stability,
   });
+}
+
+export async function getVendors(): Promise<VendorInfo[]> {
+  return invoke('get_vendors');
 }
 
 export async function getBlockDevices(): Promise<BlockDevice[]> {
@@ -29,8 +33,8 @@ export async function requestWriteAuthorization(devicePath: string): Promise<boo
   return invoke('request_write_authorization', { devicePath });
 }
 
-export async function downloadImage(fileUrl: string, fileUrlSha?: string | null): Promise<string> {
-  return invoke('download_image', { fileUrl, fileUrlSha });
+export async function downloadImage(fileUrl: string, shaUrl?: string | null): Promise<string> {
+  return invoke('download_image', { fileUrl, shaUrl });
 }
 
 export async function getDownloadProgress(): Promise<DownloadProgress> {
@@ -301,8 +305,8 @@ export async function getCachedBoardImage(boardSlug: string): Promise<string | n
  * Returns a data URI (data:image/png;base64,...) for the cached logo, or null
  * if the logo is unavailable (offline + not cached).
  */
-export async function getCachedVendorLogo(vendorId: string, logoUrl: string): Promise<string | null> {
-  return invoke('get_cached_vendor_logo', { vendorId, logoUrl });
+export async function getCachedVendorLogo(vendorSlug: string): Promise<string | null> {
+  return invoke('get_cached_vendor_logo', { vendorSlug });
 }
 
 // ============================================================================

--- a/src/hooks/useVendorLogos.ts
+++ b/src/hooks/useVendorLogos.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { BoardInfo } from '../types';
-import { preloadImage } from '../utils';
 import { getCachedVendorLogo } from './useTauri';
 import { VENDOR } from '../config';
 
@@ -29,18 +28,19 @@ export function useVendorLogos(boards: BoardInfo[] | null, isActive: boolean) {
     }
   }, [isActive]);
 
-  // Preload logos via local cache, falling back to remote
+  // Preload logos via local cache using vendor slugs
   useEffect(() => {
     if (!isActive || !boards?.length || state.isLoaded) return;
 
-    const vendorLogos = new Map<string, string>();
+    // Collect unique vendor slugs from boards
+    const vendorSlugs = new Set<string>();
     for (const board of boards) {
-      if (board.vendor && board.vendor !== VENDOR.FALLBACK_ID && board.vendor_logo) {
-        vendorLogos.set(board.vendor, board.vendor_logo);
+      if (board.vendor && board.vendor !== VENDOR.FALLBACK_ID) {
+        vendorSlugs.add(board.vendor);
       }
     }
 
-    if (vendorLogos.size === 0) {
+    if (vendorSlugs.size === 0) {
       setState({ failedLogos: new Set(), cachedUrls: new Map(), isLoaded: true });
       return;
     }
@@ -49,24 +49,19 @@ export function useVendorLogos(boards: BoardInfo[] | null, isActive: boolean) {
     const failed = new Set<string>();
     const cached = new Map<string, string>();
 
-    vendorLogos.forEach((logoUrl, vendorId) => {
-      // Try cache first, fall back to remote preload
-      getCachedVendorLogo(vendorId, logoUrl).then((dataUri) => {
+    vendorSlugs.forEach((vendorSlug) => {
+      // Fetch logo via backend cache (constructs URL from slug)
+      getCachedVendorLogo(vendorSlug).then((dataUri) => {
         if (dataUri) {
-          cached.set(vendorId, dataUri);
+          cached.set(vendorSlug, dataUri);
         } else {
-          // No cached path — try remote preload as fallback
-          return preloadImage(logoUrl).then((success) => {
-            if (!success) {
-              failed.add(vendorId);
-            }
-          });
+          failed.add(vendorSlug);
         }
       }).catch(() => {
-        failed.add(vendorId);
+        failed.add(vendorSlug);
       }).finally(() => {
         loaded++;
-        if (loaded >= vendorLogos.size) {
+        if (loaded >= vendorSlugs.size) {
           setState({ failedLogos: failed, cachedUrls: cached, isLoaded: true });
         }
       });
@@ -75,7 +70,7 @@ export function useVendorLogos(boards: BoardInfo[] | null, isActive: boolean) {
 
   // Helper to get effective vendor (considering failed logos)
   const getEffectiveVendor = useCallback((board: BoardInfo): string => {
-    if (!board.vendor_logo || state.failedLogos.has(board.vendor)) {
+    if (!board.vendor || state.failedLogos.has(board.vendor)) {
       return VENDOR.FALLBACK_ID;
     }
     return board.vendor || VENDOR.FALLBACK_ID;
@@ -83,7 +78,7 @@ export function useVendorLogos(boards: BoardInfo[] | null, isActive: boolean) {
 
   // Check if a vendor has a valid logo
   const hasValidLogo = useCallback((board: BoardInfo): boolean => {
-    return !!(board.vendor_logo && !state.failedLogos.has(board.vendor));
+    return !!(board.vendor && !state.failedLogos.has(board.vendor));
   }, [state.failedLogos]);
 
   return {
@@ -127,14 +122,14 @@ export function useManufacturerList(
       standardCount: number;
     }> = {};
 
-    // Build vendor map with board counts, platinum board counts, and standard board counts
+    // Build vendor map with board counts and support tier counts
     for (const board of boards) {
       const validLogo = hasValidLogo(board);
       const vendorId = validLogo ? (board.vendor || VENDOR.FALLBACK_ID) : VENDOR.FALLBACK_ID;
       const vendorName = validLogo ? (board.vendor_name || 'Other') : 'Other';
-      // Prefer cached local URL over remote URL
+      // Use cached local data URI for vendor logo
       const vendorLogo = validLogo
-        ? (cachedUrls.get(board.vendor) || board.vendor_logo)
+        ? (cachedUrls.get(board.vendor) || null)
         : null;
 
       if (!vendorMap[vendorId]) {
@@ -149,12 +144,12 @@ export function useManufacturerList(
       vendorMap[vendorId].count++;
 
       // Increment platinum count if this board has platinum support
-      if (board.has_platinum_support) {
+      if (board.support_tier === 'platinum') {
         vendorMap[vendorId].platinumCount++;
       }
 
       // Increment standard count if this board has standard support
-      if (board.has_standard_support) {
+      if (board.support_tier === 'standard') {
         vendorMap[vendorId].standardCount++;
       }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,20 +1,28 @@
 export interface BoardInfo {
   slug: string;
   name: string;
+  /** Vendor slug identifier (e.g., "radxa") */
   vendor: string;
+  /** Vendor display name (e.g., "Radxa") */
   vendor_name: string;
-  vendor_logo: string | null;
+  /** Support tier: "platinum", "standard", "community", "eos", "tvb", "wip" */
+  support_tier: string;
   image_count: number;
-  has_standard_support: boolean;
-  has_community_support: boolean;
-  has_platinum_support: boolean;
-  has_eos_support: boolean;
-  has_tvb_support: boolean;
-  has_wip_support: boolean;
+  /** Whether desktop environment images are available */
+  has_desktop: boolean;
+  /** Whether this board is featured/promoted */
+  promoted: boolean;
+  /** System-on-Chip model (e.g., "RK3588") */
+  soc?: string;
+  /** CPU architecture (e.g., "arm64") */
+  architecture?: string;
+  /** Short board description */
+  summary?: string;
 }
 
 export interface ImageInfo {
-  armbian_version: string;
+  /** Armbian release version (e.g., "24.02.0") */
+  release: string;
   distro_release: string;
   kernel_branch: string;
   kernel_version: string;
@@ -22,14 +30,48 @@ export interface ImageInfo {
   preinstalled_application: string;
   promoted: boolean;
   file_url: string;
-  file_url_sha: string | null;
+  /** Direct CDN download URL */
+  direct_url: string;
+  /** SHA256 checksum file URL */
+  sha_url: string | null;
   file_size: number;
-  download_repository: string;
-  /** Flash method: "block" (default SD/USB) or "qdl" (Qualcomm EDL) */
-  flash_method: string;
+  /** Stability level: "stable", "edge", "nightly" */
+  stability: string;
+  /** Image format: "sd" (block), "qdl" (Qualcomm EDL), "rootfs", "qemu", "hyperv" */
+  format: string;
+  /** Companion files (bootloaders, firmware, etc.) */
+  companions: CompanionInfo[];
+  /** Display variant files for multi-panel devices */
+  display_variants: DisplayVariantInfo[];
   // Custom image fields
   is_custom?: boolean;
   custom_path?: string;
+}
+
+/** Companion file info (bootloader, fip, recovery, etc.) */
+export interface CompanionInfo {
+  type_name: string;
+  label: string;
+  url: string;
+  size_bytes: number;
+}
+
+/** Display variant for multi-panel devices */
+export interface DisplayVariantInfo {
+  label: string;
+  url: string;
+  size_bytes: number;
+}
+
+/** Vendor/manufacturer information from the API */
+export interface VendorInfo {
+  slug: string;
+  name: string;
+  logo_url?: string;
+  website?: string;
+  description?: string;
+  board_count: number;
+  partner_tier?: string;
 }
 
 export interface BlockDevice {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -144,29 +144,20 @@ export function getErrorMessage(error: unknown, fallback: string = 'An error occ
   return fallback;
 }
 
+/** Support tier priority order (lower index = higher priority) */
+const SUPPORT_TIER_ORDER = ['platinum', 'standard', 'community', 'eos', 'tvb', 'wip'];
+
 /**
  * Sort comparator for boards: Platinum > Standard > Community > EOS > TVB > WIP > Others (alphabetically)
  */
 export function compareBoardsBySupport<T extends {
-  has_platinum_support: boolean;
-  has_standard_support: boolean;
-  has_community_support: boolean;
-  has_eos_support: boolean;
-  has_tvb_support: boolean;
-  has_wip_support: boolean;
+  support_tier: string;
   name: string;
 }>(a: T, b: T): number {
-  if (a.has_platinum_support && !b.has_platinum_support) return -1;
-  if (!a.has_platinum_support && b.has_platinum_support) return 1;
-  if (a.has_standard_support && !b.has_standard_support) return -1;
-  if (!a.has_standard_support && b.has_standard_support) return 1;
-  if (a.has_community_support && !b.has_community_support) return -1;
-  if (!a.has_community_support && b.has_community_support) return 1;
-  if (a.has_eos_support && !b.has_eos_support) return -1;
-  if (!a.has_eos_support && b.has_eos_support) return 1;
-  if (a.has_tvb_support && !b.has_tvb_support) return -1;
-  if (!a.has_tvb_support && b.has_tvb_support) return 1;
-  if (a.has_wip_support && !b.has_wip_support) return -1;
-  if (!a.has_wip_support && b.has_wip_support) return 1;
+  const aIdx = SUPPORT_TIER_ORDER.indexOf(a.support_tier);
+  const bIdx = SUPPORT_TIER_ORDER.indexOf(b.support_tier);
+  const aPriority = aIdx === -1 ? SUPPORT_TIER_ORDER.length : aIdx;
+  const bPriority = bIdx === -1 ? SUPPORT_TIER_ORDER.length : bIdx;
+  if (aPriority !== bPriority) return aPriority - bPriority;
   return a.name.localeCompare(b.name);
 }


### PR DESCRIPTION
This branch migrates the imager's data layer from the legacy `github.armbian.com/armbian-images.json` dump to the new structured `api.armbian.com/api/v1` REST API. Boards, images, and vendors are now served via dedicated, paginated endpoints, which lets us drop a lot of the ad-hoc parsing and grouping logic and rely on fields the API already provides (`support_tier`, `format`, `companions`, `display_variants`).

On the backend, a shared HTTP client sends the `X-Armbian-Client` header on every call, uses a short 10s timeout for metadata (keeping the long timeout only for image downloads), and hardens the integration with `error_for_status`, proper URL-encoded query params, paginated board fetch with an empty-page break and a hard safety cap, plus atomic JSON cache writes with a unique tmp suffix. The disk cache remains the offline fallback and is now populated from the REST responses. Picture-cache prepopulation and background refresh also flow through the new board and vendor lists.

On the frontend, the types (`BoardInfo`, `ImageInfo`, the new `VendorInfo`), IPC wrappers, image modal, board badges, vendor logo loading, and the QDL/flash hook are all updated to consume the REST schema. Routine tracing logs were demoted to debug level so uploaded session logs stay readable; user-facing events (flash start/end, device add/remove, authorization, errors) remain at info.