### PR TITLE
fix(download): use direct_url so filename keeps its extension

### DIFF
--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -275,7 +275,9 @@ export function useFlashOperation({
     }, POLLING.DOWNLOAD_PROGRESS);
 
     try {
-      const path = await downloadImage(image.file_url, image.sha_url);
+      // direct_url carries the full filename; file_url is the pretty
+      // mirror-selector URL (legacy redi_url) and has no extension.
+      const path = await downloadImage(image.direct_url, image.sha_url);
       setImagePath(path);
       if (intervalRef.current) clearInterval(intervalRef.current);
       startFlash(path);


### PR DESCRIPTION
The REST API migration mapped `ApiImage.download.file_url` to `ImageInfo.file_url`, but that field is the pretty mirror-selector URL (successor of the legacy `redi_url`) and has no file extension. Pre-migration the download pipeline consumed the legacy `file_url`, which on the new API is exposed as `direct_url`.

The side effect is that downloaded images get saved with names like `Noble_vendor_gnome`: `needs_decompression` can't recognise the format, XZ data is written raw to the SD card, and the QDL extractor chokes on a TAR header that's actually `7zXZ` magic bytes. Passing `direct_url` at the one call site restores the pre-migration behaviour — the backend extracts a filename with the correct extension and the decompression / QDL pipelines work again. `file_url` stays where it belongs: UI keys and per-image storage identifiers.