### PR TITLE
fix(cache): switch to sort_by_key for LRU ordering

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -128,7 +128,7 @@ fn get_cached_files_by_age_internal() -> Result<Vec<CacheEntry>, String> {
     }
 
     // Sort by modification time (oldest first for LRU eviction)
-    files.sort_by(|a, b| a.modified.cmp(&b.modified));
+    files.sort_by_key(|a| a.modified);
 
     Ok(files)
 }


### PR DESCRIPTION
Clippy 1.95 (rust-1.95.0) added the `unnecessary_sort_by` lint, which triggers on the explicit `sort_by` closure used for the LRU cache ordering in `cache.rs`. Since the comparator is a plain `Ord` on a single `SystemTime` key, the shorter `sort_by_key` form is equivalent and lets the compiler skip the extra closure indirection. The previous local toolchain (1.91) didn't ship this lint yet, which is why it only showed up on CI after the last release build.