### PR TITLE
chore(deps): patch rustls-webpki and rand advisories

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3211,7 +3211,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Updates two Rust dependencies in src-tauri/Cargo.lock to resolve open Dependabot advisories.

rustls-webpki moves from 0.103.10 to 0.103.12, closing GHSA-xgp8-3hg3-c2mh and GHSA-965h-392x-2mh5 (both low-severity name-constraint parsing issues). rand goes from 0.9.2 to 0.9.4 for GHSA-cq8v-f236-94qc (unsound interaction with custom loggers through rand::rng()).

The older rand 0.7/0.8 and glib 0.18 copies that Dependabot also flags come in transitively through wry/webkit2gtk and the Tauri plugin stack, so they can only move when Tauri/wry publish a release that upgrades them — not something we can fix from the lockfile.

cargo fmt --check and cargo clippy --all-targets --all-features -- -D warnings pass locally.