### PR TITLE
os-info: add Ubuntu 26.04 (resolute)

### DIFF
--- a/src/config/os-info.ts
+++ b/src/config/os-info.ts
@@ -33,6 +33,7 @@ export const OS_INFO: Record<string, OsInfoConfig> = {
   // Ubuntu releases
   'noble': { name: 'Ubuntu 24.04', color: 'transparent', logo: ubuntuLogo },
   'jammy': { name: 'Ubuntu 22.04', color: 'transparent', logo: ubuntuLogo },
+  'resolute': { name: 'Ubuntu 25.10', color: 'transparent', logo: ubuntuLogo },
   'plucky': { name: 'Ubuntu 25.04', color: 'transparent', logo: ubuntuLogo },
   'oracular': { name: 'Ubuntu 24.10', color: 'transparent', logo: ubuntuLogo },
   'focal': { name: 'Ubuntu 20.04', color: 'transparent', logo: ubuntuLogo },

--- a/src/config/os-info.ts
+++ b/src/config/os-info.ts
@@ -33,7 +33,7 @@ export const OS_INFO: Record<string, OsInfoConfig> = {
   // Ubuntu releases
   'noble': { name: 'Ubuntu 24.04', color: 'transparent', logo: ubuntuLogo },
   'jammy': { name: 'Ubuntu 22.04', color: 'transparent', logo: ubuntuLogo },
-  'resolute': { name: 'Ubuntu 25.10', color: 'transparent', logo: ubuntuLogo },
+  'resolute': { name: 'Ubuntu 26.04', color: 'transparent', logo: ubuntuLogo },
   'plucky': { name: 'Ubuntu 25.04', color: 'transparent', logo: ubuntuLogo },
   'oracular': { name: 'Ubuntu 24.10', color: 'transparent', logo: ubuntuLogo },
   'focal': { name: 'Ubuntu 20.04', color: 'transparent', logo: ubuntuLogo },


### PR DESCRIPTION
## Summary

armbian.github.io is publishing **26.2.5 resolute** images (Ubuntu 26.04 LTS base), but [`OS_INFO`](src/config/os-info.ts) had no entry for the `resolute` codename. `getOsInfo('resolute')` returned `null` and the Imager UI fell back to a generic placeholder box icon, dropping the friendly "Ubuntu 26.04" label too.

Visible symptom (from the website screenshot that surfaced this):

> Armbian 26.2.5 resolute — CLI / Vendor 6.1.115 → generic gray box icon
> Armbian 26.2.5 resolute — CLI / Current 6.18.24 → generic gray box icon
> Armbian 26.2.1 trixie  — CLI / Vendor 6.1.115 → Debian swirl icon ✓

## Change

One-line addition to [`src/config/os-info.ts`](src/config/os-info.ts) `OS_INFO`:

```ts
'resolute': { name: 'Ubuntu 26.04', color: 'transparent', logo: ubuntuLogo },
```

Inserted between `jammy` and `plucky` to keep the existing top-to-bottom ordering rough-chronological within the Ubuntu group.

<img width="1862" height="286" alt="image" src="https://github.com/user-attachments/assets/4b846171-6b7d-4790-85d4-79760d65c005" />