### PR TITLE
feat(flash): show only the progress phases that will actually run

### DIFF
--- a/src/components/flash/FlashPhaseDots.tsx
+++ b/src/components/flash/FlashPhaseDots.tsx
@@ -1,19 +1,29 @@
-import { stageToPhase, type FlashStage } from './FlashStageIcon';
+import { stagePhase, PHASE_ORDER, type FlashPhase, type FlashStage } from './FlashStageIcon';
 
-// Macro phases shown as dots: Download · Prepare · Write · Verify.
-const PHASES = 4;
+/** Active dot index for the current stage within the planned phases. */
+function activeIndex(stage: FlashStage, phases: FlashPhase[]): number {
+  if (stage === 'complete') return phases.length;
+  const phase = stagePhase(stage);
+  if (!phase) return 0;
+  const idx = phases.indexOf(phase);
+  if (idx !== -1) return idx;
+  // Stage belongs to a phase we didn't plan: treat earlier-ranked planned phases as done.
+  const rank = PHASE_ORDER.indexOf(phase);
+  return phases.filter((p) => PHASE_ORDER.indexOf(p) < rank).length;
+}
 
-/** Phase dots under the progress bar; current phase elongates into a pill. */
-export function FlashPhaseDots({ stage }: { stage: FlashStage }) {
-  const active = stageToPhase(stage);
+/** Progress dots for the phases that will actually run; the current one elongates into a pill. */
+export function FlashPhaseDots({ stage, phases }: { stage: FlashStage; phases: FlashPhase[] }) {
+  if (phases.length < 2) return null;
+  const active = activeIndex(stage, phases);
   return (
     <div className="flash-dots" role="presentation" aria-hidden="true">
-      {Array.from({ length: PHASES }, (_, i) => {
+      {phases.map((phase, i) => {
         const done = i < active;
         const current = i === active;
         return (
           <span
-            key={i}
+            key={phase}
             className={`flash-dot${done ? ' is-done' : ''}${current ? ' is-current' : ''}`}
           />
         );

--- a/src/components/flash/FlashProgress.tsx
+++ b/src/components/flash/FlashProgress.tsx
@@ -36,6 +36,7 @@ export function FlashProgress({
 
   const {
     stage,
+    phases,
     progress,
     error,
     showShaWarning,
@@ -149,7 +150,7 @@ export function FlashProgress({
                       style={isIndeterminate ? undefined : { width: `${progress}%` }}
                     />
                   </div>
-                  <FlashPhaseDots stage={stage} />
+                  <FlashPhaseDots stage={stage} phases={phases} />
                 </div>
               )}
 

--- a/src/components/flash/FlashStageIcon.tsx
+++ b/src/components/flash/FlashStageIcon.tsx
@@ -86,27 +86,33 @@ export function getStageKey(stage: FlashStage): string {
   }
 }
 
-/** Maps a stage to its macro phase index (0=Download, 1=Prepare, 2=Write, 3=Verify, 4=all done). */
+/** Macro phases shown as progress dots: Download · Prepare · Write · Verify. */
+export type FlashPhase = 'download' | 'prepare' | 'write' | 'verify';
+
+/** Canonical phase order. */
 // eslint-disable-next-line react-refresh/only-export-components
-export function stageToPhase(stage: FlashStage): number {
+export const PHASE_ORDER: FlashPhase[] = ['download', 'prepare', 'write', 'verify'];
+
+/** Maps a stage to its macro phase, or null for stages without a dot (authorizing/complete/error). */
+// eslint-disable-next-line react-refresh/only-export-components
+export function stagePhase(stage: FlashStage): FlashPhase | null {
   switch (stage) {
-    case 'authorizing':
     case 'downloading':
     case 'verifying_sha':
-      return 0;
+      return 'download';
     case 'decompressing':
     case 'extracting':
-      return 1;
+      return 'prepare';
     case 'qdl_sahara':
     case 'qdl_firehose':
     case 'flashing':
-      return 2;
+      return 'write';
     case 'verifying':
-      return 3;
+      return 'verify';
+    case 'authorizing':
     case 'complete':
-      return 4;
     case 'error':
-      return 0;
+      return null;
   }
 }
 

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ImageInfo, BlockDevice, AutoconfigConfig } from '../types';
-import type { FlashStage } from '../components/flash/FlashStageIcon';
+import { PHASE_ORDER, type FlashStage, type FlashPhase } from '../components/flash/FlashStageIcon';
 import {
   downloadImage,
   flashImage,
@@ -21,10 +21,11 @@ import {
   getQdlDevices,
   continueDownloadWithoutSha,
   cleanupFailedDownload,
+  listCachedImages,
 } from './useTauri';
 import { getSkipVerify } from './useSettings';
 import { POLLING, CACHE, STORAGE_KEYS } from '../config';
-import { getErrorMessage } from '../utils';
+import { getErrorMessage, armbianIdentityKey, isCompressedImage } from '../utils';
 import { isDeviceConnected } from '../utils/deviceUtils';
 import { isShaUnavailableError, translateQdlError } from '../utils/errorUtils';
 
@@ -38,6 +39,7 @@ interface UseFlashOperationProps {
 
 interface UseFlashOperationReturn {
   stage: FlashStage;
+  phases: FlashPhase[];
   progress: number;
   error: string | null;
   imagePath: string | null;
@@ -67,6 +69,15 @@ async function cleanupImageSafely(
 }
 
 
+function buildPhases(opts: { download: boolean; prepare: boolean; verify: boolean }): FlashPhase[] {
+  const phases: FlashPhase[] = [];
+  if (opts.download) phases.push('download');
+  if (opts.prepare) phases.push('prepare');
+  phases.push('write');
+  if (opts.verify) phases.push('verify');
+  return phases;
+}
+
 export function useFlashOperation({
   image,
   device,
@@ -77,6 +88,7 @@ export function useFlashOperation({
 
   // Operation state
   const [stage, setStage] = useState<FlashStage>('authorizing');
+  const [phases, setPhases] = useState<FlashPhase[]>(() => [...PHASE_ORDER]);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [imagePath, setImagePath] = useState<string | null>(null);
@@ -208,12 +220,14 @@ export function useFlashOperation({
     try {
       // QDL custom images (.tar) flash directly; extraction is internal
       if (isQdlMode) {
+        setPhases(buildPhases({ download: false, prepare: true, verify: false }));
         setImagePath(customPath);
         startFlash(customPath);
         return;
       }
 
       const needsDecompress = await checkNeedsDecompression(customPath);
+      setPhases(buildPhases({ download: false, prepare: needsDecompress, verify: !skipVerifyRef.current }));
 
       if (needsDecompress) {
         setStage('decompressing');
@@ -431,6 +445,26 @@ export function useFlashOperation({
       if (image.is_custom && image.custom_path) {
         await handleCustomImage(image.custom_path);
       } else {
+        // A cache hit returns the decompressed .img immediately, skipping download + prepare.
+        let cached = false;
+        if (!isQdlMode) {
+          try {
+            const key = armbianIdentityKey(image.direct_url);
+            if (key) {
+              const list = await listCachedImages();
+              cached = list.some((c) => armbianIdentityKey(c.filename) === key);
+            }
+          } catch {
+            cached = false;
+          }
+        }
+        setPhases(
+          buildPhases({
+            download: !cached,
+            prepare: isQdlMode || (!cached && isCompressedImage(image.direct_url)),
+            verify: !isQdlMode && !skipVerifyRef.current,
+          })
+        );
         startDownload();
       }
     } catch (err) {
@@ -482,9 +516,12 @@ export function useFlashOperation({
     if (imagePath) {
       // QDL: skip block-device authorization (USB access handled by OS)
       if (isQdlMode) {
+        setPhases(buildPhases({ download: false, prepare: true, verify: false }));
         startFlash(imagePath);
         return;
       }
+      // The image is already downloaded/decompressed: only write (and maybe verify) remain.
+      setPhases(buildPhases({ download: false, prepare: false, verify: !skipVerifyRef.current }));
       // Re-authorize before re-flashing the existing image
       setStage('authorizing');
       try {
@@ -536,6 +573,7 @@ export function useFlashOperation({
 
   return {
     stage,
+    phases,
     progress,
     error,
     imagePath,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -88,6 +88,15 @@ export interface ArmbianFilenameInfo {
   desktop: string | null;
 }
 
+/** Compression extensions an Armbian image can carry. */
+export const COMPRESSION_EXTS = ['.xz', '.gz', '.zst', '.bz2'] as const;
+
+/** True when a filename or URL ends with a known compression extension (i.e. a decompress step runs). */
+export function isCompressedImage(nameOrUrl: string): boolean {
+  const lower = nameOrUrl.toLowerCase();
+  return COMPRESSION_EXTS.some((ext) => lower.endsWith(ext));
+}
+
 /** Parse an Armbian image filename into structured metadata across three conventions: Standard
  * `Armbian_{version}_{board}_...`, Labeled `Armbian_{label}_{version}_{board}_...` (label when parts[1] non-numeric), Prefixed `Armbian-unofficial_{version}_{board}_...`. */
 export function parseArmbianFilename(filename: string): ArmbianFilenameInfo | null {
@@ -95,7 +104,7 @@ export function parseArmbianFilename(filename: string): ArmbianFilenameInfo | nu
 
   // Strip compression extensions, then .img
   let name = basename;
-  for (const ext of ['.xz', '.gz', '.zst', '.bz2']) {
+  for (const ext of COMPRESSION_EXTS) {
     if (name.endsWith(ext)) {
       name = name.slice(0, -ext.length);
       break;


### PR DESCRIPTION
The phase dots under the flashing bar were always four, even when a step never ran. They now match the actual work: a cached image drops the download and prepare dots, a disabled post-flash check drops verify, QDL shows extract and write, and a retry shows just the write, so the row no longer promises stages that won't happen.