### PR TITLE
fix(ui): keep marquee text aligned while scrolling

### DIFF
--- a/src/components/shared/MarqueeText.tsx
+++ b/src/components/shared/MarqueeText.tsx
@@ -14,51 +14,33 @@ export function MarqueeText({ text, maxWidth, className = '' }: MarqueeTextProps
   // No explicit cap → measure the real container width and react to layout changes.
   const responsive = maxWidth === undefined;
   const containerRef = useRef<HTMLSpanElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
   const [isOverflow, setIsOverflow] = useState(false);
-  const [scrollPercent, setScrollPercent] = useState(50);
+  const [shiftPx, setShiftPx] = useState(0);
 
   useEffect(() => {
+    let active = true;
+
     const checkOverflow = () => {
-      if (!containerRef.current) return;
+      const container = containerRef.current;
+      const measure = measureRef.current;
+      if (!active || !container || !measure) return;
 
-      const computedStyle = window.getComputedStyle(containerRef.current);
-
-      const measureSpan = document.createElement('span');
-      measureSpan.style.cssText = `
-        position: absolute;
-        visibility: hidden;
-        white-space: nowrap;
-        font-family: ${computedStyle.fontFamily};
-        font-size: ${computedStyle.fontSize};
-        font-weight: ${computedStyle.fontWeight};
-        letter-spacing: ${computedStyle.letterSpacing};
-        text-transform: ${computedStyle.textTransform};
-      `;
-      measureSpan.textContent = text;
-
-      let singleTextWidth = 0;
-      try {
-        document.body.appendChild(measureSpan);
-        singleTextWidth = measureSpan.offsetWidth;
-      } finally {
-        if (measureSpan.parentNode) {
-          measureSpan.parentNode.removeChild(measureSpan);
-        }
-      }
-
-      // Compare against the actual available width when responsive, else the cap.
-      const available = responsive ? containerRef.current.clientWidth : maxWidth;
-      const overflow = available > 0 && singleTextWidth > available;
+      // The hidden in-container span inherits the real rendered font, so its width
+      // is exact even across font swaps (a detached styled clone is not).
+      const textWidth = measure.offsetWidth;
+      const available = responsive ? container.clientWidth : maxWidth;
+      const overflow = available > 0 && textWidth > available + 2;
       setIsOverflow(overflow);
 
       if (overflow) {
-        const scrollDistance = singleTextWidth + UI.MARQUEE.SEPARATOR_WIDTH;
-        const totalWidth = scrollDistance * 2;
-        setScrollPercent((scrollDistance / totalWidth) * 100);
+        // Exact pixel shift: copy 2 lands where copy 1 started, so the loop is seamless.
+        setShiftPx(textWidth + UI.MARQUEE.SEPARATOR_WIDTH);
       }
     };
 
     const timer = setTimeout(checkOverflow, 50);
+    document.fonts?.ready.then(checkOverflow);
     window.addEventListener('resize', checkOverflow);
 
     // In responsive mode the column width can change without a window resize
@@ -70,6 +52,7 @@ export function MarqueeText({ text, maxWidth, className = '' }: MarqueeTextProps
     }
 
     return () => {
+      active = false;
       clearTimeout(timer);
       window.removeEventListener('resize', checkOverflow);
       observer?.disconnect();
@@ -83,12 +66,24 @@ export function MarqueeText({ text, maxWidth, className = '' }: MarqueeTextProps
       style={{ maxWidth: responsive ? '100%' : `${maxWidth}px` }}
       title={text}
     >
+      <span ref={measureRef} className="marquee-measure" aria-hidden="true">
+        {text}
+      </span>
       <span
         className="marquee-content"
-        style={isOverflow ? { '--scroll-percent': `-${scrollPercent}%` } as React.CSSProperties : undefined}
+        style={isOverflow ? { '--marquee-shift': `-${shiftPx}px` } as React.CSSProperties : undefined}
       >
         {text}
-        {isOverflow && <>&nbsp;{text}</>}
+        {isOverflow && (
+          <>
+            <span
+              className="marquee-spacer"
+              aria-hidden="true"
+              style={{ width: UI.MARQUEE.SEPARATOR_WIDTH }}
+            />
+            {text}
+          </>
+        )}
       </span>
     </span>
   );

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -957,17 +957,32 @@ button.list-item:disabled:hover {
 
 /* MARQUEE TEXT (Shared Component) */
 .marquee-container {
+  position: relative;
   display: inline-block;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
+/* Scroll must start at the text's beginning even inside centered parents. */
 .marquee-container.overflow {
   text-overflow: clip;
+  text-align: left;
+}
+
+/* In-flow hidden twin used to measure the true rendered text width. */
+.marquee-measure {
+  position: absolute;
+  visibility: hidden;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 .marquee-container .marquee-content {
+  display: inline-block;
+}
+
+.marquee-spacer {
   display: inline-block;
 }
 
@@ -980,7 +995,7 @@ button.list-item:disabled:hover {
     transform: translateX(0);
   }
   100% {
-    transform: translateX(var(--scroll-percent, -50%));
+    transform: translateX(var(--marquee-shift, -50%));
   }
 }
 


### PR DESCRIPTION
Long device and OS names on the flash screen turned into overlapping garbage while scrolling, the same marquee bug we had already chased down on the website mockup. The animation moved by a percentage that never matched the real text width, so every loop drifted a little further off. It now measures the rendered text with an in-flow twin and shifts by exact pixels, and the scroll starts from the left even inside centered parents.

![telegram-cloud-photo-size-4-5857301924288335265-w](https://github.com/user-attachments/assets/edff1faa-0970-4331-becf-0d6c5af46500)
