### PR TITLE
Surface flash write failures instead of a blank error screen

### DIFF
--- a/src-tauri/src/flash/linux/writer.rs
+++ b/src-tauri/src/flash/linux/writer.rs
@@ -158,15 +158,18 @@ pub async fn flash_image(
 
         if let Err(e) = device.write_all(&buffer[..bytes_read]) {
             log_error!(MODULE, "Write error at byte {}: {}", written, e);
-            return Err(format!("Failed to write at byte {}: {}", written, e));
+            return Err(crate::flash::write_failed_err(written, e));
         }
 
         written += bytes_read as u64;
         bytes_since_sync += bytes_read as u64;
 
         if bytes_since_sync >= config::logging::LINUX_SYNC_INTERVAL {
-            unsafe {
-                libc::fdatasync(device_fd);
+            // A failing card often surfaces only here, when buffered pages hit the device.
+            if unsafe { libc::fdatasync(device_fd) } != 0 {
+                let e = std::io::Error::last_os_error();
+                log_error!(MODULE, "fdatasync failed at byte {}: {}", written, e);
+                return Err(crate::flash::write_failed_err(written, e));
             }
             bytes_since_sync = 0;
             state.written_bytes.store(written, Ordering::SeqCst);
@@ -178,10 +181,10 @@ pub async fn flash_image(
     tracker.finish();
     log_debug!(MODULE, "Syncing...");
 
-    device.flush().ok();
-    unsafe {
-        libc::fsync(device_fd);
-    }
+    device
+        .flush()
+        .map_err(|e| crate::flash::write_failed_err(written, e))?;
+    crate::flash::fsync_checked(device_fd, written)?;
     sync_device(device_path);
 
     if verify {
@@ -222,7 +225,9 @@ fn quick_erase(device: &mut File) -> Result<(), String> {
 
     crate::flash::write_zeros(device, erase_size, chunk_size)?;
 
-    device.flush().ok();
+    device
+        .flush()
+        .map_err(|e| crate::flash::write_failed_err(0, e))?;
 
     // Rewind so the image write starts at offset 0.
     device

--- a/src-tauri/src/flash/macos/writer.rs
+++ b/src-tauri/src/flash/macos/writer.rs
@@ -209,10 +209,10 @@ pub fn quick_erase(device: &mut File, device_fd: i32) -> Result<(), String> {
 
     crate::flash::write_zeros(device, erase_size, chunk_size)?;
 
-    device.flush().ok();
-    unsafe {
-        libc::fsync(device_fd);
-    }
+    device
+        .flush()
+        .map_err(|e| crate::flash::write_failed_err(0, e))?;
+    crate::flash::fsync_checked(device_fd, 0)?;
 
     // Rewind so the image write starts at offset 0.
     unsafe {
@@ -351,10 +351,7 @@ async fn do_flash_work(
                 image_size,
                 e
             );
-            return Err(format!(
-                "Failed to write to device at byte {}: {}",
-                written, e
-            ));
+            return Err(crate::flash::write_failed_err(written, e));
         }
 
         // Count real image bytes, not the sector padding.
@@ -367,10 +364,10 @@ async fn do_flash_work(
     tracker.finish();
     log_debug!(MODULE, "Syncing...");
 
-    device.flush().ok();
-    unsafe {
-        libc::fsync(device_fd);
-    }
+    device
+        .flush()
+        .map_err(|e| crate::flash::write_failed_err(written, e))?;
+    crate::flash::fsync_checked(device_fd, written)?;
     sync_device(device_path);
 
     // Verification reuses the same fd, so no extra auth prompt.

--- a/src-tauri/src/flash/mod.rs
+++ b/src-tauri/src/flash/mod.rs
@@ -132,6 +132,19 @@ pub(crate) fn unmount_device(device_path: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Tagged device-write failure; the frontend maps `[WRITE_FAILED:<offset>]` to a translated message.
+pub(crate) fn write_failed_err(offset: u64, e: impl std::fmt::Display) -> String {
+    format!("[WRITE_FAILED:{}] {}", offset, e)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn fsync_checked(fd: i32, written: u64) -> Result<(), String> {
+    if unsafe { libc::fsync(fd) } != 0 {
+        return Err(write_failed_err(written, std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
 /// Write `total` zero bytes in `chunk_size` chunks, shared by the platform
 /// quick_erase routines (which keep their own seek/sync).
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src-tauri/src/flash/windows.rs
+++ b/src-tauri/src/flash/windows.rs
@@ -95,8 +95,13 @@ pub async fn flash_image(
         }
 
         device.write_all(&buffer[..bytes_read]).map_err(|e| {
-            log_error!(MODULE, "Failed to write to device: {}", e);
-            format!("Failed to write to device: {}", e)
+            log_error!(
+                MODULE,
+                "Failed to write to device at byte {}: {}",
+                written,
+                e
+            );
+            super::write_failed_err(written, e)
         })?;
 
         written += bytes_read as u64;
@@ -106,8 +111,10 @@ pub async fn flash_image(
     }
 
     log_debug!(MODULE, "Flushing write cache...");
-    device.flush().ok();
-    flush_device_buffers(&device)?;
+    device
+        .flush()
+        .map_err(|e| super::write_failed_err(written, e))?;
+    flush_device_buffers(&device).map_err(|e| super::write_failed_err(written, e))?;
 
     tracker.finish();
 

--- a/src/components/shared/ErrorDisplay.tsx
+++ b/src/components/shared/ErrorDisplay.tsx
@@ -16,6 +16,8 @@ interface ErrorDisplayProps {
 
 export function ErrorDisplay({ error, onRetry, onCancel, compact = false }: ErrorDisplayProps) {
   const { t } = useTranslation();
+  // The screen must never be message-less, whatever upstream race produced an empty error.
+  const message = error.trim() || t('error.flashFailed');
   const [uploading, setUploading] = useState(false);
   const [pasteUrl, setPasteUrl] = useState<string | null>(null);
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string | null>(null);
@@ -61,7 +63,7 @@ export function ErrorDisplay({ error, onRetry, onCancel, compact = false }: Erro
       <div className="error-display-compact">
         <div className="error-display-message">
           <CircleAlert size={18} />
-          <span>{error}</span>
+          <span>{message}</span>
         </div>
         <div className="error-display-actions">
           {onRetry && (
@@ -107,7 +109,7 @@ export function ErrorDisplay({ error, onRetry, onCancel, compact = false }: Erro
 
       <div className="error-screen__main">
         <h2 className="error-screen__title">{t('flash.failed')}</h2>
-        {error && <p className="error-screen__hint">{error}</p>}
+        <p className="error-screen__hint">{message}</p>
 
         {/* Remedy card: one surface; upload-logs row turns into the QR + share link. */}
         <div className="error-screen__card">

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -27,7 +27,7 @@ import { getSkipVerify } from './useSettings';
 import { POLLING, CACHE, STORAGE_KEYS } from '../config';
 import { getErrorMessage, armbianIdentityKey, isCompressedImage } from '../utils';
 import { isDeviceConnected } from '../utils/deviceUtils';
-import { isShaUnavailableError, translateQdlError } from '../utils/errorUtils';
+import { isShaUnavailableError, translateFlashError } from '../utils/errorUtils';
 
 interface UseFlashOperationProps {
   image: ImageInfo;
@@ -103,6 +103,11 @@ export function useFlashOperation({
   const flashWriteSeenRef = useRef<boolean>(false);
   const hasStartedRef = useRef<boolean>(false);
   const deviceDisconnectedRef = useRef<boolean>(false);
+  const userCancelledRef = useRef<boolean>(false);
+  // Precedence latch: a specific error (real write failure) beats the generic
+  // "device disconnected", never the reverse, regardless of which path fires first.
+  const shownErrorRef = useRef<null | 'generic' | 'specific'>(null);
+  const pendingCleanupRef = useRef<Promise<void> | null>(null);
   const skipVerifyRef = useRef<boolean>(false);
   // Keep the latest opt-in profile config for the event-driven flash flow.
   const autoconfigRef = useRef<AutoconfigConfig | null>(autoconfig ?? null);
@@ -144,6 +149,18 @@ export function useFlashOperation({
     }
   }, []);
 
+  /** Single exit into the error screen: never empty, honors the precedence latch. */
+  const failFlash = useCallback(
+    (message: string, specific = true) => {
+      if (shownErrorRef.current === 'specific') return;
+      if (shownErrorRef.current === 'generic' && !specific) return;
+      shownErrorRef.current = specific ? 'specific' : 'generic';
+      setError(message.trim() || t('error.flashFailed'));
+      setStage('error');
+    },
+    [t]
+  );
+
   /** Whether the current image uses QDL (Qualcomm EDL) flashing */
   const isQdlMode = image.format === 'qdl';
 
@@ -172,22 +189,26 @@ export function useFlashOperation({
 
   /** Handle device disconnection during operations */
   const handleDeviceDisconnectedInternal = useCallback(async () => {
+    if (deviceDisconnectedRef.current) return;
     deviceDisconnectedRef.current = true;
     setShowShaWarning(false);
-    try {
-      await cleanupFailedDownload();
-    } catch {
-      // Ignore cleanup errors
-    }
     clearIntervals();
-    try {
-      await cancelOperation();
-    } catch {
-      // Ignore
-    }
-    setError(t('error.deviceDisconnected'));
-    setStage('error');
-  }, [t, clearIntervals]);
+    // Error state first, synchronously: the UI must never wait on backend cleanup.
+    failFlash(t('error.deviceDisconnected'), false);
+    pendingCleanupRef.current = (async () => {
+      try {
+        await cancelOperation();
+      } catch {
+        // Ignore
+      }
+      try {
+        await cleanupFailedDownload();
+      } catch {
+        // Ignore cleanup errors
+      }
+    })();
+    await pendingCleanupRef.current;
+  }, [t, clearIntervals, failFlash]);
 
   // Monitor device connection during active operations.
   // QDL flash stages are excluded: the USB device is busy/resets during Sahara/Firehose (expected).
@@ -240,11 +261,9 @@ export function useFlashOperation({
         startFlash(customPath);
       }
     } catch (err) {
-      if (deviceDisconnectedRef.current) return;
-      if (!(await checkDeviceOrDisconnect())) return;
-
-      setError(getErrorMessage(err, t('error.decompressionFailed')));
-      setStage('error');
+      const raw = getErrorMessage(err, '');
+      if (deviceDisconnectedRef.current && /cancel/i.test(raw)) return;
+      failFlash(raw || t('error.decompressionFailed'));
     }
   }
 
@@ -278,8 +297,7 @@ export function useFlashOperation({
         }
 
         if (prog.error && !deviceDisconnectedRef.current) {
-          setError(prog.error);
-          setStage('error');
+          failFlash(prog.error);
           if (intervalRef.current) clearInterval(intervalRef.current);
         }
       } catch {
@@ -295,20 +313,17 @@ export function useFlashOperation({
       startFlash(path);
     } catch (err) {
       if (intervalRef.current) clearInterval(intervalRef.current);
-      if (deviceDisconnectedRef.current) return;
 
       const errorMsg = getErrorMessage(err, String(err));
 
       // SHA fetch failed: show modal; the file is downloaded and kept
-      if (isShaUnavailableError(errorMsg)) {
+      if (!deviceDisconnectedRef.current && isShaUnavailableError(errorMsg)) {
         setShowShaWarning(true);
         return;
       }
 
-      if (!(await checkDeviceOrDisconnect())) return;
-
-      setError(getErrorMessage(err, t('error.downloadFailed')));
-      setStage('error');
+      if (deviceDisconnectedRef.current && /cancel/i.test(errorMsg)) return;
+      failFlash(errorMsg.trim() ? errorMsg : t('error.downloadFailed'));
     }
   }
 
@@ -362,8 +377,7 @@ export function useFlashOperation({
           }
         }
         if (prog.error && !deviceDisconnectedRef.current) {
-          setError(prog.error);
-          setStage('error');
+          failFlash(prog.error);
           if (intervalRef.current) clearInterval(intervalRef.current);
         }
       } catch {
@@ -390,12 +404,20 @@ export function useFlashOperation({
       }
     } catch (err) {
       if (intervalRef.current) clearInterval(intervalRef.current);
-      if (deviceDisconnectedRef.current) return;
 
-      if (!(await checkDeviceOrDisconnect())) return;
+      const rawError = getErrorMessage(err, String(err));
+      // User-initiated cancel: handleCancel owns navigation/messaging.
+      if (userCancelledRef.current) return;
+      // Cancel-shaped rejection triggered by the disconnect handler's own cancelOperation:
+      // the generic disconnect message is already on screen and more truthful.
+      const causedByDisconnectCancel = deviceDisconnectedRef.current && /cancel/i.test(rawError);
+      if (!causedByDisconnectCancel) {
+        failFlash(translateFlashError(rawError, t));
+      }
 
-      // Increment failure count for cached (non-custom) images
-      if (!image.is_custom && !isQdlMode) {
+      // Increment failure count for cached (non-custom) images; skip on disconnect
+      // so a card pull doesn't burn down a good cached image.
+      if (!image.is_custom && !isQdlMode && !deviceDisconnectedRef.current) {
         const currentCount = getFlashFailureCount() + 1;
         setFlashFailureCount(currentCount);
 
@@ -410,12 +432,9 @@ export function useFlashOperation({
         }
       }
 
-      if (!isQdlMode) {
+      if (!isQdlMode && !deviceDisconnectedRef.current) {
         await cleanupImageSafely(path, image.is_custom);
       }
-      const rawError = getErrorMessage(err, String(err));
-      setError(translateQdlError(rawError, t));
-      setStage('error');
     }
   }
 
@@ -424,6 +443,8 @@ export function useFlashOperation({
     setStage('authorizing');
     setProgress(0);
     setError(null);
+    shownErrorRef.current = null;
+    userCancelledRef.current = false;
 
     try {
       try {
@@ -436,8 +457,7 @@ export function useFlashOperation({
       if (!isQdlMode) {
         const authorized = await requestWriteAuthorization(device.path);
         if (!authorized) {
-          setError(t('error.authCancelled'));
-          setStage('error');
+          failFlash(t('error.authCancelled'));
           return;
         }
       }
@@ -468,8 +488,7 @@ export function useFlashOperation({
         startDownload();
       }
     } catch (err) {
-      setError(getErrorMessage(err, t('error.authFailed')));
-      setStage('error');
+      failFlash(getErrorMessage(err, t('error.authFailed')));
     }
   }
 
@@ -491,6 +510,7 @@ export function useFlashOperation({
   // === Public action handlers ===
 
   const handleCancel = async () => {
+    userCancelledRef.current = true;
     try {
       await cancelOperation();
       if (intervalRef.current) clearInterval(intervalRef.current);
@@ -510,8 +530,20 @@ export function useFlashOperation({
   };
 
   const handleRetry = async () => {
+    // Let the disconnect handler's cancel/cleanup land before restarting,
+    // so a stale is_cancelled can't race the new flash's reset.
+    if (pendingCleanupRef.current) {
+      try {
+        await pendingCleanupRef.current;
+      } catch {
+        // Ignore
+      }
+      pendingCleanupRef.current = null;
+    }
     setError(null);
     deviceDisconnectedRef.current = false;
+    userCancelledRef.current = false;
+    shownErrorRef.current = null;
 
     if (imagePath) {
       // QDL: skip block-device authorization (USB access handled by OS)
@@ -527,14 +559,12 @@ export function useFlashOperation({
       try {
         const authorized = await requestWriteAuthorization(device.path);
         if (!authorized) {
-          setError(t('error.authCancelled'));
-          setStage('error');
+          failFlash(t('error.authCancelled'));
           return;
         }
         startFlash(imagePath);
       } catch (err) {
-        setError(getErrorMessage(err, t('error.authFailed')));
-        setStage('error');
+        failFlash(getErrorMessage(err, t('error.authFailed')));
       }
     } else {
       handleAuthorization();
@@ -559,9 +589,9 @@ export function useFlashOperation({
       setImagePath(path);
       startFlash(path);
     } catch (err) {
-      if (deviceDisconnectedRef.current) return;
-      setError(getErrorMessage(err, t('error.decompressionFailed')));
-      setStage('error');
+      const raw = getErrorMessage(err, '');
+      if (deviceDisconnectedRef.current && /cancel/i.test(raw)) return;
+      failFlash(raw || t('error.decompressionFailed'));
     }
   };
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Entpacken fehlgeschlagen",
     "uploadFailed": "Hochladen fehlgeschlagen",
     "deviceDisconnected": "Gerät getrennt",
+    "writeFailed": "Das Schreiben auf das Gerät ist bei {{offset}} fehlgeschlagen. Das Gerät ist möglicherweise zu klein, defekt oder der Kartenleser wurde getrennt. Versuche eine andere Karte, einen anderen Leser oder Port.",
     "qdlDisconnected": "Das Gerät wurde während des Flashens getrennt. Verbinde es erneut im EDL-Modus und versuche es noch einmal.",
     "qdlCancelled": "Flashen abgebrochen.",
     "qdlPermissionDenied": "USB-Zugriff verweigert. Installiere unter Linux die udev-Regeln: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Decompression failed",
     "uploadFailed": "Upload failed",
     "deviceDisconnected": "Device disconnected",
+    "writeFailed": "Writing to the device failed at {{offset}}. The device may be too small, failing, or the reader was disconnected. Try another card, reader, or port.",
     "qdlDisconnected": "Device disconnected during flash. Reconnect in EDL mode and retry.",
     "qdlCancelled": "Flash cancelled.",
     "qdlPermissionDenied": "USB access denied. On Linux, install udev rules: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Error de descompresión",
     "uploadFailed": "Error al subir",
     "deviceDisconnected": "Dispositivo desconectado",
+    "writeFailed": "La escritura en el dispositivo falló en {{offset}}. El dispositivo puede ser demasiado pequeño, estar fallando o el lector se desconectó. Prueba con otra tarjeta, lector o puerto.",
     "qdlDisconnected": "El dispositivo se desconectó durante la escritura. Vuelve a conectarlo en modo EDL y reintenta.",
     "qdlCancelled": "Escritura cancelada.",
     "qdlPermissionDenied": "Acceso USB denegado. En Linux, instala las reglas udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Échec de la décompression",
     "uploadFailed": "Échec du téléversement",
     "deviceDisconnected": "Appareil déconnecté",
+    "writeFailed": "L'écriture sur le périphérique a échoué à {{offset}}. Le périphérique est peut-être trop petit, défaillant, ou le lecteur a été déconnecté. Essayez une autre carte, un autre lecteur ou un autre port.",
     "qdlDisconnected": "Appareil déconnecté pendant le flash. Reconnectez-le en mode EDL et réessayez.",
     "qdlCancelled": "Flash annulé.",
     "qdlPermissionDenied": "Accès USB refusé. Sous Linux, installez les règles udev : echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Raspakiravanje nije uspjelo",
     "uploadFailed": "Slanje nije uspjelo",
     "deviceDisconnected": "Uređaj je isključen",
+    "writeFailed": "Zapisivanje na uređaj nije uspjelo pri {{offset}}. Uređaj je možda premalen, neispravan ili je čitač odspojen. Pokušajte s drugom karticom, čitačem ili priključkom.",
     "qdlDisconnected": "Uređaj je odspojen tijekom snimanja. Ponovno ga spojite u EDL načinu rada i pokušajte ponovno.",
     "qdlCancelled": "Snimanje je otkazano.",
     "qdlPermissionDenied": "USB pristup je odbijen. Na Linuxu instalirajte udev pravila: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Decompressione non riuscita",
     "uploadFailed": "Caricamento non riuscito",
     "deviceDisconnected": "Dispositivo disconnesso",
+    "writeFailed": "La scrittura sul dispositivo è fallita a {{offset}}. Il dispositivo potrebbe essere troppo piccolo, difettoso, oppure il lettore è stato scollegato. Prova un'altra scheda, lettore o porta.",
     "qdlDisconnected": "Dispositivo disconnesso durante la scrittura. Ricollegalo in modalità EDL e riprova.",
     "qdlCancelled": "Scrittura annullata.",
     "qdlPermissionDenied": "Accesso USB negato. Su Linux, installa le regole udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "展開に失敗しました",
     "uploadFailed": "アップロードに失敗しました",
     "deviceDisconnected": "デバイスが切断されました",
+    "writeFailed": "{{offset}} の位置でデバイスへの書き込みに失敗しました。デバイスの容量不足や故障、またはリーダーの切断が原因の可能性があります。別のカード・リーダー・ポートをお試しください。",
     "qdlDisconnected": "書き込み中にデバイスが切断されました。EDLモードで接続し直して、再試行してください。",
     "qdlCancelled": "書き込みをキャンセルしました。",
     "qdlPermissionDenied": "USBへのアクセスが拒否されました。Linuxでは次のudevルールをインストールしてください： echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "압축 해제 실패",
     "uploadFailed": "업로드 실패",
     "deviceDisconnected": "장치 연결이 끊겼습니다",
+    "writeFailed": "{{offset}} 지점에서 장치 쓰기에 실패했습니다. 장치 용량이 부족하거나 고장났거나 리더기가 분리되었을 수 있습니다. 다른 카드, 리더기 또는 포트로 시도해 보세요.",
     "qdlDisconnected": "플래시 도중 장치 연결이 끊겼습니다. EDL 모드로 다시 연결한 뒤 시도하세요.",
     "qdlCancelled": "플래시를 취소했습니다.",
     "qdlPermissionDenied": "USB 접근이 거부되었습니다. Linux에서는 udev 규칙을 설치하세요: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Uitpakken mislukt",
     "uploadFailed": "Upload mislukt",
     "deviceDisconnected": "Apparaat is losgekoppeld",
+    "writeFailed": "Schrijven naar het apparaat is mislukt bij {{offset}}. Het apparaat is mogelijk te klein, defect, of de lezer is losgekoppeld. Probeer een andere kaart, lezer of poort.",
     "qdlDisconnected": "Apparaat losgekoppeld tijdens het flashen. Sluit opnieuw aan in EDL-modus en probeer het opnieuw.",
     "qdlCancelled": "Flash geannuleerd.",
     "qdlPermissionDenied": "USB-toegang geweigerd. Installeer op Linux udev-regels: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Rozpakowywanie nie powiodło się",
     "uploadFailed": "Przesyłanie nie powiodło się",
     "deviceDisconnected": "Urządzenie zostało odłączone",
+    "writeFailed": "Zapis na urządzenie nie powiódł się przy {{offset}}. Urządzenie może być za małe, uszkodzone lub czytnik został odłączony. Spróbuj innej karty, czytnika lub portu.",
     "qdlDisconnected": "Urządzenie odłączone podczas zapisu. Podłącz je ponownie w trybie EDL i spróbuj jeszcze raz.",
     "qdlCancelled": "Zapis anulowany.",
     "qdlPermissionDenied": "Odmowa dostępu do USB. W systemie Linux zainstaluj reguły udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Falha na descompactação",
     "uploadFailed": "Falha no envio",
     "deviceDisconnected": "Dispositivo desconectado",
+    "writeFailed": "A gravação no dispositivo falhou em {{offset}}. O dispositivo pode ser pequeno demais, estar com defeito ou o leitor foi desconectado. Tente outro cartão, leitor ou porta.",
     "qdlDisconnected": "Dispositivo desconectado durante a gravação. Reconecte em modo EDL e tente novamente.",
     "qdlCancelled": "Gravação cancelada.",
     "qdlPermissionDenied": "Acesso USB negado. No Linux, instale as regras udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Falha na descompressão",
     "uploadFailed": "Falha no envio",
     "deviceDisconnected": "Dispositivo desligado",
+    "writeFailed": "A escrita no dispositivo falhou em {{offset}}. O dispositivo pode ser demasiado pequeno, estar com defeito ou o leitor foi desligado. Tente outro cartão, leitor ou porta.",
     "qdlDisconnected": "O dispositivo desligou-se durante a gravação. Volte a ligá-lo em modo EDL e tente novamente.",
     "qdlCancelled": "Gravação cancelada.",
     "qdlPermissionDenied": "Acesso USB negado. No Linux, instale as regras udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Ошибка распаковки",
     "uploadFailed": "Ошибка отправки",
     "deviceDisconnected": "Устройство отключено",
+    "writeFailed": "Запись на устройство не удалась на отметке {{offset}}. Возможно, устройство слишком маленькое, неисправно или картридер был отключён. Попробуйте другую карту, картридер или порт.",
     "qdlDisconnected": "Устройство отключено во время записи. Подключите его заново в режиме EDL и повторите попытку.",
     "qdlCancelled": "Запись отменена.",
     "qdlPermissionDenied": "Доступ к USB запрещён. В Linux установите правила udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Razširjanje ni uspelo",
     "uploadFailed": "Nalaganje ni uspelo",
     "deviceDisconnected": "Naprava je bila odklopljena",
+    "writeFailed": "Zapisovanje na napravo ni uspelo pri {{offset}}. Naprava je morda premajhna, okvarjena ali pa je bil čitalnik odklopljen. Poskusite z drugo kartico, čitalnikom ali vrati.",
     "qdlDisconnected": "Naprava odklopljena med zapisovanjem. Ponovno povežite v načinu EDL in poskusite znova.",
     "qdlCancelled": "Zapisovanje preklicano.",
     "qdlPermissionDenied": "Dostop do USB zavrnjen. V Linuxu namestite pravila udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Uppackningen misslyckades",
     "uploadFailed": "Uppladdningen misslyckades",
     "deviceDisconnected": "Enheten kopplades bort",
+    "writeFailed": "Skrivningen till enheten misslyckades vid {{offset}}. Enheten kan vara för liten, trasig eller så kopplades läsaren bort. Prova ett annat kort, en annan läsare eller port.",
     "qdlDisconnected": "Enheten kopplades bort under flashningen. Anslut igen i EDL-läge och försök på nytt.",
     "qdlCancelled": "Flashningen avbröts.",
     "qdlPermissionDenied": "USB-åtkomst nekad. På Linux, installera udev-regler: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Açma başarısız",
     "uploadFailed": "Yükleme başarısız",
     "deviceDisconnected": "Cihaz bağlantısı kesildi",
+    "writeFailed": "{{offset}} konumunda cihaza yazma başarısız oldu. Cihaz çok küçük veya arızalı olabilir ya da okuyucunun bağlantısı kesilmiş olabilir. Başka bir kart, okuyucu veya bağlantı noktası deneyin.",
     "qdlDisconnected": "Yazma sırasında cihaz bağlantısı kesildi. EDL modunda yeniden bağlayıp tekrar deneyin.",
     "qdlCancelled": "Yazma iptal edildi.",
     "qdlPermissionDenied": "USB erişimi reddedildi. Linux'ta udev kurallarını yükleyin: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "Помилка розпакування",
     "uploadFailed": "Помилка завантаження",
     "deviceDisconnected": "Пристрій було від'єднано",
+    "writeFailed": "Запис на пристрій не вдався на позначці {{offset}}. Пристрій може бути замалим, несправним або кардрідер було від'єднано. Спробуйте іншу картку, кардрідер чи порт.",
     "qdlDisconnected": "Пристрій від'єднано під час прошивки. Підключіть знову в режимі EDL та повторіть.",
     "qdlCancelled": "Прошивку скасовано.",
     "qdlPermissionDenied": "Доступ до USB заборонено. У Linux встановіть правила udev: echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -125,6 +125,7 @@
     "decompressionFailed": "解压失败",
     "uploadFailed": "上传失败",
     "deviceDisconnected": "设备已断开连接",
+    "writeFailed": "在 {{offset}} 处写入设备失败。设备可能容量不足、已损坏，或读卡器已断开。请尝试更换卡、读卡器或接口。",
     "qdlDisconnected": "烧录过程中设备断开连接。请在 EDL 模式下重新连接后重试。",
     "qdlCancelled": "烧录已取消。",
     "qdlPermissionDenied": "USB 访问被拒绝。在 Linux 上，请安装 udev 规则：echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"05c6\", ATTR{idProduct}==\"9008\", MODE=\"0666\"' | sudo tee /etc/udev/rules.d/51-qdl.rules && echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf && sudo udevadm control --reload-rules",

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,12 +1,23 @@
 // Parse the backend's tagged error strings (e.g. [SHA_UNAVAILABLE]) and map them to i18n keys
 
+import { formatBytes } from './index';
+
+type TFn = (key: string, opts?: Record<string, unknown>) => string;
+
 /** Check if a SHA error indicates the SHA file was unavailable (not a mismatch) */
 export function isShaUnavailableError(error: string): boolean {
   return error.includes('[SHA_UNAVAILABLE]');
 }
 
+/** Map tagged backend flash errors ([WRITE_FAILED:offset], [QDL_*]) to translated messages */
+export function translateFlashError(error: string, t: TFn): string {
+  const write = error.match(/\[WRITE_FAILED:(\d+)\]/);
+  if (write) return t('error.writeFailed', { offset: formatBytes(Number(write[1])) });
+  return translateQdlError(error, t);
+}
+
 /** Map QDL backend error tags to translated user-facing messages */
-export function translateQdlError(error: string, t: (key: string) => string): string {
+export function translateQdlError(error: string, t: TFn): string {
   if (error.includes('[QDL_DISCONNECTED]')) return t('error.qdlDisconnected');
   if (error.includes('[QDL_CANCELLED]')) return t('error.qdlCancelled');
   if (error.includes('[QDL_PERMISSION_DENIED]')) return t('error.qdlPermissionDenied');


### PR DESCRIPTION
Flashing to a failing microSD on Linux left a reviewer staring at an almost empty window: the backend caught the write error but the device monitor won the race and cleared the screen before the message could land. Write and sync results are now checked on all three platforms, the specific failure always takes priority over the generic disconnect one, and it surfaces as a translated message with the failing offset in all 18 languages.