### PR TITLE
fix(profiles): keep the flash profile picker in sync with Settings

### DIFF
--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -4,7 +4,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ErrorDisplay, DeviceIcon, getDeviceBadge, BoardImage, MarqueeText } from '../shared';
-import type { BlockDevice, AutoconfigProfile } from '../../types';
+import type { BlockDevice, AutoconfigProfile, AutoconfigProfilesChangedDetail } from '../../types';
 import { getBlockDevices, getQdlDevices } from '../../hooks/useTauri';
 import { getAutoconfigProfiles } from '../../hooks/useSettings';
 import { useAsyncData } from '../../hooks/useAsyncData';
@@ -57,17 +57,14 @@ export function DevicePanel({
   const showAutoconfig = supportsAutoconfig;
 
   // Opt-in autoconfig profile picker (flash-time only, Armbian images).
-  const [profiles, setProfiles] = useState<AutoconfigProfile[]>([]);
   const [showProfilePicker, setShowProfilePicker] = useState(false);
   const [selectedProfileId, setSelectedProfileId] = useState('');
 
-  // Load profiles when the confirm view is visible (Armbian images only).
-  useEffect(() => {
-    if (!selectedDevice || !showAutoconfig) return;
-    getAutoconfigProfiles()
-      .then(setProfiles)
-      .catch(() => setProfiles([]));
-  }, [selectedDevice, showAutoconfig]);
+  const { data: profilesData, reload: reloadProfiles } = useAsyncData<AutoconfigProfile[]>(
+    () => (showAutoconfig ? getAutoconfigProfiles() : Promise.resolve([])),
+    [showAutoconfig]
+  );
+  const profiles = profilesData ?? [];
 
   // Notify App of the opt-in selection; default "" means no profile (unchanged behaviour).
   const handleProfileChange = useCallback((id: string) => {
@@ -78,6 +75,30 @@ export function DevicePanel({
       new CustomEvent(AUTOCONFIG_PROFILE_SELECTED_EVENT, { detail: { id: id || null } })
     );
   }, []);
+
+  // Keep the picker in sync with profile create/edit/delete done in Settings, without re-mounting.
+  useEffect(() => {
+    if (!showAutoconfig) return;
+    const onProfilesChanged = (e: Event) => {
+      const detail = (e as CustomEvent<AutoconfigProfilesChangedDetail>).detail;
+      reloadProfiles();
+      if (detail?.action === 'deleted' && detail.id === selectedProfileId) {
+        handleProfileChange('');
+      }
+    };
+    window.addEventListener(EVENTS.PROFILES_CHANGED, onProfilesChanged);
+    return () => window.removeEventListener(EVENTS.PROFILES_CHANGED, onProfilesChanged);
+  }, [showAutoconfig, selectedProfileId, reloadProfiles, handleProfileChange]);
+
+  // Auto-select only a profile created from this panel's "Create new" shortcut.
+  useEffect(() => {
+    const onCreated = (e: Event) => {
+      const id = (e as CustomEvent<{ id: string }>).detail?.id;
+      if (id) handleProfileChange(id);
+    };
+    window.addEventListener(EVENTS.AUTOCONFIG_PROFILE_CREATED, onCreated);
+    return () => window.removeEventListener(EVENTS.AUTOCONFIG_PROFILE_CREATED, onCreated);
+  }, [handleProfileChange]);
 
   // Open Settings on the profiles tab with the new-profile editor already open.
   const openProfileCreator = useCallback(() => {

--- a/src/components/settings/AutoconfigSection.tsx
+++ b/src/components/settings/AutoconfigSection.tsx
@@ -24,11 +24,6 @@ import {
   renderPresetPreview,
 } from '../../config/autoconfig';
 
-/** Notifies the rest of the app (e.g. the flash profile picker) that profiles changed. */
-function notifyProfilesChanged(): void {
-  window.dispatchEvent(new Event(EVENTS.PROFILES_CHANGED));
-}
-
 /** Count fields that hold a real value (true booleans or non-empty strings). */
 function countSet(values: unknown[]): number {
   return values.filter((v) => v === true || (typeof v === 'string' && v.trim() !== '')).length;
@@ -199,10 +194,11 @@ function SectionCard({
 
 interface AutoconfigSectionProps {
   autoCreate?: boolean;
+  onSaved?: () => void;
 }
 
 // Profiles tab: lists saved autoconfig profiles (master) and edits one (detail).
-export function AutoconfigSection({ autoCreate = false }: AutoconfigSectionProps) {
+export function AutoconfigSection({ autoCreate = false, onSaved }: AutoconfigSectionProps) {
   const { t } = useTranslation();
   const { showSuccess, showError } = useToasts();
 
@@ -269,13 +265,18 @@ export function AutoconfigSection({ autoCreate = false }: AutoconfigSectionProps
       return;
     }
     try {
+      const wasNew = isNew;
       const toSave: AutoconfigProfile = { ...draft, name, updatedAt: Date.now() };
       await upsertAutoconfigProfile(toSave);
       await loadProfiles();
-      notifyProfilesChanged();
-      showSuccess(isNew ? t('settings.autoconfig.toastCreated') : t('settings.autoconfig.toastUpdated'));
+      showSuccess(wasNew ? t('settings.autoconfig.toastCreated') : t('settings.autoconfig.toastUpdated'));
       setDraft(null);
       setIsNew(false);
+      // Only a profile created from the flash flow's shortcut should auto-select in the picker.
+      if (autoCreate && wasNew) {
+        window.dispatchEvent(new CustomEvent(EVENTS.AUTOCONFIG_PROFILE_CREATED, { detail: { id: toSave.id } }));
+      }
+      onSaved?.();
     } catch (error) {
       console.error('Failed to save autoconfig profile:', error);
       showError(t('settings.autoconfig.toastError'));
@@ -288,7 +289,6 @@ export function AutoconfigSection({ autoCreate = false }: AutoconfigSectionProps
     try {
       await deleteAutoconfigProfile(pendingDelete.id);
       await loadProfiles();
-      notifyProfilesChanged();
       showSuccess(t('settings.autoconfig.toastDeleted'));
     } catch (error) {
       console.error('Failed to delete autoconfig profile:', error);

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -57,7 +57,8 @@ export function SettingsModal({ isOpen, onClose, initialView = 'appearance', sta
       case 'preferences':
         return <PreferencesSection />;
       case 'profiles':
-        return <AutoconfigSection autoCreate={startProfileCreation} />;
+        // Launched from the flash flow: return there once the profile is saved.
+        return <AutoconfigSection autoCreate={startProfileCreation} onSaved={startProfileCreation ? onClose : undefined} />;
       case 'storage':
         return <StorageSection />;
       case 'developer':

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -43,6 +43,7 @@ export const EVENTS = {
   SETTINGS_CHANGED: 'armbian-settings-changed',
   CACHE_IMAGE_REUSE: 'armbian-cache-image-reuse',
   PROFILES_CHANGED: 'armbian-autoconfig-profiles-changed',
+  AUTOCONFIG_PROFILE_CREATED: 'armbian-autoconfig-profile-created',
   OPEN_SETTINGS: 'armbian-open-settings',
 } as const;
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -2,7 +2,7 @@
 
 import { load } from '@tauri-apps/plugin-store';
 import { CACHE, EVENTS, SETTINGS } from '../config';
-import type { AutoconfigProfile } from '../types';
+import type { AutoconfigProfile, AutoconfigProfilesChangedDetail } from '../types';
 let storeInstance: Awaited<ReturnType<typeof load>> | null = null;
 let storePromise: Promise<Awaited<ReturnType<typeof load>>> | null = null;
 
@@ -259,10 +259,10 @@ export async function setArmbianBoardDetection(mode: string): Promise<void> {
 
 // Autoconfig profiles: named first-boot presets stored client-side and applied only on explicit selection.
 
-/** Notify open views (settings, flash) that the stored profile list changed */
-function emitProfilesChanged(): void {
+/** Notify open views (settings, flash) which profile changed and how */
+function emitProfilesChanged(detail: AutoconfigProfilesChangedDetail): void {
   if (typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent(EVENTS.PROFILES_CHANGED));
+    window.dispatchEvent(new CustomEvent(EVENTS.PROFILES_CHANGED, { detail }));
   }
 }
 
@@ -277,13 +277,12 @@ export async function getAutoconfigProfiles(): Promise<AutoconfigProfile[]> {
   }
 }
 
-/** Persist the full profile list and broadcast the change */
+/** Persist the full profile list (callers broadcast the specific change) */
 export async function saveAutoconfigProfiles(list: AutoconfigProfile[]): Promise<void> {
   try {
     const store = await getStore();
     await store.set(SETTINGS.KEYS.AUTOCONFIG_PROFILES, list);
     await store.save();
-    emitProfilesChanged();
   } catch (error) {
     throw new Error(`Failed to save autoconfig profiles: ${error}`);
   }
@@ -299,6 +298,7 @@ export async function upsertAutoconfigProfile(p: AutoconfigProfile): Promise<Aut
     list.push(p);
   }
   await saveAutoconfigProfiles(list);
+  emitProfilesChanged({ id: p.id, action: index >= 0 ? 'updated' : 'created' });
   return list;
 }
 
@@ -307,6 +307,7 @@ export async function deleteAutoconfigProfile(id: string): Promise<AutoconfigPro
   const list = await getAutoconfigProfiles();
   const next = list.filter(existing => existing.id !== id);
   await saveAutoconfigProfiles(next);
+  emitProfilesChanged({ id, action: 'deleted' });
   return next;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -211,3 +211,11 @@ export interface AutoconfigProfile {
   updatedAt: number;
   config: AutoconfigConfig;
 }
+
+export type AutoconfigProfileChangeAction = 'created' | 'updated' | 'deleted';
+
+/** Detail carried by the EVENTS.PROFILES_CHANGED CustomEvent */
+export interface AutoconfigProfilesChangedDetail {
+  id: string;
+  action: AutoconfigProfileChangeAction;
+}


### PR DESCRIPTION
The flash profile picker only loaded its list when the confirm view mounted, so a profile created through the picker's "Create new" shortcut didn't show up until you stepped back and re-picked the device (#154). 

Profile changes now broadcast a typed { id, action } event and the picker reacts to it directly: it reloads the list and clears the selection if the chosen profile gets deleted. 

A profile created from the "Create new" shortcut is auto-selected and drops you back on the flash page once saved, while one created the normal way from Settings just appears in the list without hijacking your current selection.

Closes #154
