### PR TITLE
fix(images): hide UFS images from the catalog

### DIFF
--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -29,11 +29,19 @@ fn is_flashable_format(format: &str) -> bool {
     matches!(format, "sd" | "block" | "qdl")
 }
 
+/// UFS images are raw provisioning images (no GPT) for QDL/firehose, not a block
+/// device — writing one to an SD card yields a non-booting card. Drop until QDL UFS lands.
+fn is_writable_storage(storage: Option<&str>) -> bool {
+    !matches!(storage, Some(s) if s.eq_ignore_ascii_case("ufs"))
+}
+
 /// Map a list of API images to frontend-facing ImageInfo, sorted by promoted first then release
 pub fn map_images(api_images: Vec<ApiImage>) -> Vec<ImageInfo> {
     let mut images: Vec<ImageInfo> = api_images
         .iter()
-        .filter(|api| is_flashable_format(&api.format))
+        .filter(|api| {
+            is_flashable_format(&api.format) && is_writable_storage(api.storage.as_deref())
+        })
         .map(map_image)
         .collect();
 


### PR DESCRIPTION
On Qualcomm boards like the Radxa Dragon Q6A, UFS images showed up in the catalog and could be flashed, but writing one to an SD card just produced a non-booting card.

The API returns them with format "sd" while marking them storage "ufs": they're raw provisioning images without a GPT, meant for QDL/firehose rather than a block device. The catalog filter only looked at the format and ignored the storage field, so they slipped through.

The listing now also drops images whose storage is UFS, leaving only the SD-flashable variants. They'll come back once QDL UFS flashing is wired up.
