### PR TITLE
Flash UFS images to Qualcomm boards over EDL

### DIFF
--- a/crates/armbian-write-conf/Cargo.lock
+++ b/crates/armbian-write-conf/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "ext4-view",
  "gptman",
  "mbrman",
+ "tempfile",
 ]
 
 [[package]]
@@ -121,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "ext4-view"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +140,12 @@ dependencies = [
  "bitflags",
  "crc",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fnv"
@@ -141,6 +158,17 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
 
 [[package]]
 name = "gptman"
@@ -165,6 +193,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -198,6 +232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,10 +256,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "serde"
@@ -284,6 +343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +415,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/armbian-write-conf/Cargo.toml
+++ b/crates/armbian-write-conf/Cargo.toml
@@ -10,3 +10,6 @@ armbian-ext4fs = { path = "vendor/armbian-ext4fs" }
 gptman = "3"
 mbrman = "0"
 ext4-view = { version = "0.9", features = ["std"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/armbian-write-conf/src/detect.rs
+++ b/crates/armbian-write-conf/src/detect.rs
@@ -6,8 +6,12 @@ use std::path::Path;
 
 use crate::WriteConfError;
 
-/// Logical sector size assumed for image layout (Armbian images use 512).
-const SECTOR_SIZE: u64 = 512;
+/// Logical sector sizes we probe: 512 for SD/eMMC, 4096 for UFS (e.g. Radxa Dragon
+/// Q6A). The GPT primary header ("EFI PART") sits at LBA1, i.e. one sector in, so the
+/// sector size is recovered by checking where that signature lands.
+const SECTOR_SIZE_512: u64 = 512;
+const SECTOR_SIZE_4096: u64 = 4096;
+const GPT_SIG: &[u8; 8] = b"EFI PART";
 /// Offset of the ext4 superblock within a partition, and its magic value.
 const EXT4_SB_OFFSET: u64 = 0x438;
 const EXT4_MAGIC: [u8; 2] = [0x53, 0xEF];
@@ -40,10 +44,10 @@ pub struct RootfsPartition {
 /// Detect partition scheme (GPT if protective-MBR type 0xEE or "EFI PART" sig, else MBR) and locate the Linux
 /// ext4 rootfs: prefer a root-named/typed partition, else largest used, then gate on ext4 superblock magic.
 pub fn detect_rootfs(image_path: &Path) -> Result<RootfsPartition, WriteConfError> {
-    let scheme = detect_scheme(image_path)?;
+    let (scheme, sector_size) = detect_scheme(image_path)?;
     let (offset, len) = match scheme {
-        Scheme::Gpt => locate_gpt_rootfs(image_path)?,
-        Scheme::Mbr => locate_mbr_rootfs(image_path)?,
+        Scheme::Gpt => locate_gpt_rootfs(image_path, sector_size)?,
+        Scheme::Mbr => locate_mbr_rootfs(image_path, sector_size)?,
     };
     verify_ext4(image_path, offset)?;
     Ok(RootfsPartition {
@@ -53,8 +57,8 @@ pub fn detect_rootfs(image_path: &Path) -> Result<RootfsPartition, WriteConfErro
     })
 }
 
-/// Decide GPT vs MBR by inspecting the protective MBR entry and the LBA1 signature.
-fn detect_scheme(image_path: &Path) -> Result<Scheme, WriteConfError> {
+/// Decide GPT vs MBR and recover the logical sector size from the "EFI PART" location.
+fn detect_scheme(image_path: &Path) -> Result<(Scheme, u64), WriteConfError> {
     let mut f = File::open(image_path)?;
 
     // Protective-MBR first-entry type byte lives at 0x1C2.
@@ -62,23 +66,29 @@ fn detect_scheme(image_path: &Path) -> Result<Scheme, WriteConfError> {
     f.seek(SeekFrom::Start(0x1C2))?;
     f.read_exact(&mut pmbr_type)?;
 
-    // GPT header signature "EFI PART" at start of LBA1.
-    let mut sig = [0u8; 8];
-    f.seek(SeekFrom::Start(SECTOR_SIZE))?;
-    let sig_read = f.read(&mut sig).unwrap_or(0);
-
-    let has_gpt_sig = sig_read == 8 && &sig == b"EFI PART";
-    if pmbr_type[0] == 0xEE || has_gpt_sig {
-        Ok(Scheme::Gpt)
+    // UFS images put the GPT header at offset 4096, not 512 — probe both so the
+    // partition offsets below scale by the right sector size.
+    if let Some(sector_size) = probe_gpt_sector_size(&mut f) {
+        Ok((Scheme::Gpt, sector_size))
+    } else if pmbr_type[0] == 0xEE {
+        Ok((Scheme::Gpt, SECTOR_SIZE_512))
     } else {
-        Ok(Scheme::Mbr)
+        Ok((Scheme::Mbr, SECTOR_SIZE_512))
     }
 }
 
+/// Return the sector size at whose LBA1 the "EFI PART" signature is found, if any.
+fn probe_gpt_sector_size(f: &mut File) -> Option<u64> {
+    [SECTOR_SIZE_512, SECTOR_SIZE_4096].into_iter().find(|&s| {
+        let mut sig = [0u8; 8];
+        f.seek(SeekFrom::Start(s)).is_ok() && f.read_exact(&mut sig).is_ok() && &sig == GPT_SIG
+    })
+}
+
 /// Locate the rootfs partition in a GPT-partitioned image.
-fn locate_gpt_rootfs(image_path: &Path) -> Result<(u64, u64), WriteConfError> {
+fn locate_gpt_rootfs(image_path: &Path, sector_size: u64) -> Result<(u64, u64), WriteConfError> {
     let mut f = File::open(image_path)?;
-    let gpt = gptman::GPT::read_from(&mut f, SECTOR_SIZE)
+    let gpt = gptman::GPT::read_from(&mut f, sector_size)
         .map_err(|e| WriteConfError::UnsupportedImage(format!("GPT parse failed: {e}")))?;
 
     // Linux filesystem-data partition type GUID (0FC63DAF-8483-4772-8E79-3D69D8477DE4).
@@ -95,8 +105,8 @@ fn locate_gpt_rootfs(image_path: &Path) -> Result<(u64, u64), WriteConfError> {
         if !p.is_used() {
             continue;
         }
-        let start = p.starting_lba * SECTOR_SIZE;
-        let len = (p.ending_lba - p.starting_lba + 1) * SECTOR_SIZE;
+        let start = p.starting_lba * sector_size;
+        let len = (p.ending_lba - p.starting_lba + 1) * sector_size;
 
         if p.partition_name.as_str().to_lowercase().contains("root") && by_name.is_none() {
             by_name = Some((start, len));
@@ -116,9 +126,9 @@ fn locate_gpt_rootfs(image_path: &Path) -> Result<(u64, u64), WriteConfError> {
 }
 
 /// Locate the rootfs partition in an MBR-partitioned image.
-fn locate_mbr_rootfs(image_path: &Path) -> Result<(u64, u64), WriteConfError> {
+fn locate_mbr_rootfs(image_path: &Path, sector_size: u64) -> Result<(u64, u64), WriteConfError> {
     let mut f = File::open(image_path)?;
-    let mbr = mbrman::MBR::read_from(&mut f, SECTOR_SIZE as u32)
+    let mbr = mbrman::MBR::read_from(&mut f, sector_size as u32)
         .map_err(|e| WriteConfError::UnsupportedImage(format!("MBR parse failed: {e}")))?;
 
     let mut linux: Option<(u64, u64)> = None;
@@ -128,8 +138,8 @@ fn locate_mbr_rootfs(image_path: &Path) -> Result<(u64, u64), WriteConfError> {
         if !p.is_used() {
             continue;
         }
-        let start = p.starting_lba as u64 * SECTOR_SIZE;
-        let len = p.sectors as u64 * SECTOR_SIZE;
+        let start = p.starting_lba as u64 * sector_size;
+        let len = p.sectors as u64 * sector_size;
 
         // 0x83 is the Linux native partition type.
         if p.sys == 0x83 && linux.map(|(_, l)| len > l).unwrap_or(true) {
@@ -180,4 +190,89 @@ pub(crate) fn verify_ext4(image_path: &Path, base: u64) -> Result<(), WriteConfE
     Err(WriteConfError::NoExt4Rootfs(
         "ext4 superblock magic 0xEF53 not found at rootfs partition".into(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    const LINUX_FS_GUID: [u8; 16] = [
+        0xAF, 0x3D, 0xC6, 0x0F, 0x83, 0x84, 0x72, 0x47, 0x8E, 0x79, 0x3D, 0x69, 0xD8, 0x47, 0x7D,
+        0xE4,
+    ];
+
+    /// Build a 1 MiB GPT image with a single Linux partition spanning the usable area,
+    /// carrying a valid ext4 superblock magic. Returns (bytes, expected rootfs offset, len).
+    fn make_gpt_image(sector_size: u64) -> (Vec<u8>, u64, u64) {
+        let disk_len = 1024 * 1024;
+        let mut cur = Cursor::new(vec![0u8; disk_len]);
+        let mut gpt = gptman::GPT::new_from(&mut cur, sector_size, [0x11; 16]).unwrap();
+
+        let start = gpt.header.first_usable_lba;
+        let end = gpt.header.last_usable_lba;
+        gpt[1] = gptman::GPTPartitionEntry {
+            partition_type_guid: LINUX_FS_GUID,
+            unique_partition_guid: [0x22; 16],
+            starting_lba: start,
+            ending_lba: end,
+            attribute_bits: 0,
+            partition_name: "rootfs".into(),
+        };
+        gpt.write_into(&mut cur).unwrap();
+
+        let mut bytes = cur.into_inner();
+        let offset = start * sector_size;
+        // Plant the ext4 superblock magic so verify_ext4 accepts the partition.
+        let sb = (offset + EXT4_SB_OFFSET) as usize;
+        bytes[sb] = EXT4_MAGIC[0];
+        bytes[sb + 1] = EXT4_MAGIC[1];
+
+        (bytes, offset, (end - start + 1) * sector_size)
+    }
+
+    fn write_temp(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut tf = tempfile::NamedTempFile::new().unwrap();
+        tf.write_all(bytes).unwrap();
+        tf.flush().unwrap();
+        tf
+    }
+
+    #[test]
+    fn detects_gpt_rootfs_512() {
+        let (bytes, offset, len) = make_gpt_image(SECTOR_SIZE_512);
+        let tf = write_temp(&bytes);
+        let part = detect_rootfs(tf.path()).unwrap();
+        assert_eq!(part.scheme, Scheme::Gpt);
+        assert_eq!(part.offset, offset);
+        assert_eq!(part.len, len);
+    }
+
+    #[test]
+    fn detects_gpt_rootfs_4096() {
+        let (bytes, offset, len) = make_gpt_image(SECTOR_SIZE_4096);
+        let tf = write_temp(&bytes);
+        let part = detect_rootfs(tf.path()).unwrap();
+        assert_eq!(part.scheme, Scheme::Gpt);
+        // 4096-sector image: rootfs starts at a 4096-aligned offset the 512 path would miss.
+        assert_eq!(part.offset, offset);
+        assert_eq!(part.len, len);
+        assert_eq!(offset % SECTOR_SIZE_4096, 0);
+    }
+
+    #[test]
+    fn probe_returns_sector_size_of_signature() {
+        let (b512, _, _) = make_gpt_image(SECTOR_SIZE_512);
+        let (b4096, _, _) = make_gpt_image(SECTOR_SIZE_4096);
+        let f512 = write_temp(&b512);
+        let f4096 = write_temp(&b4096);
+        assert_eq!(
+            probe_gpt_sector_size(&mut File::open(f512.path()).unwrap()),
+            Some(SECTOR_SIZE_512)
+        );
+        assert_eq!(
+            probe_gpt_sector_size(&mut File::open(f4096.path()).unwrap()),
+            Some(SECTOR_SIZE_4096)
+        );
+    }
 }

--- a/src-tauri/src/autoconfig.rs
+++ b/src-tauri/src/autoconfig.rs
@@ -286,6 +286,8 @@ mod tests {
         assert!(!render_preset(&c).contains("PRESET_NET_WIFI_SSID"));
 
         c.apply_network = Some(true);
+        // Wi-Fi credentials are only emitted when Wi-Fi is enabled.
+        c.wifi_enabled = Some(true);
         let out = render_preset(&c);
         assert!(out.contains("PRESET_NET_CHANGE_DEFAULTS=\"1\"\n"));
         assert!(out.contains("PRESET_NET_WIFI_SSID=\"home\"\n"));
@@ -294,6 +296,10 @@ mod tests {
     #[test]
     fn lang_flag_uses_y_n() {
         let mut c = empty();
+        // Localization keys are only emitted once a full first user is defined.
+        c.user_name = Some("u".to_string());
+        c.user_password = Some("p".to_string());
+        c.user_real_name = Some("User".to_string());
         c.lang_based_on_location = Some(true);
         assert!(render_preset(&c).contains("SET_LANG_BASED_ON_LOCATION=\"y\"\n"));
         c.lang_based_on_location = Some(false);

--- a/src-tauri/src/commands/qdl_operations.rs
+++ b/src-tauri/src/commands/qdl_operations.rs
@@ -6,7 +6,7 @@ use tauri::State;
 use crate::qdl;
 use crate::qdl::QdlDevice;
 use crate::utils::qdl_temp_dir;
-use crate::{log_error, log_info};
+use crate::{log_error, log_info, log_warn};
 
 use super::state::AppState;
 
@@ -74,4 +74,71 @@ pub async fn flash_qdl_image(
     }
 
     result
+}
+
+/// Flash a UFS image (a downloaded + decompressed `.img`) to a device in EDL mode via a
+/// single raw Firehose write. The loader is resolved from `soc`, then from `board_slug`,
+/// since the Armbian API reports `soc` as null for these boards.
+#[tauri::command]
+pub async fn flash_qdl_ufs_image(
+    image_path: String,
+    soc: String,
+    board_slug: String,
+    serial: Option<String>,
+    autoconfig: Option<crate::autoconfig::AutoconfigConfig>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    log_info!("qdl_operations", "Starting QDL UFS flash: {}", image_path);
+
+    let flash_state = state.flash_state.clone();
+    flash_state.reset();
+
+    let loader_path = qdl::loader::ensure_loader(&soc, &board_slug)
+        .await
+        .map_err(|e| {
+            log_error!("qdl_operations", "Firehose loader unavailable: {}", e);
+            e
+        })?;
+
+    // Provisioning descriptor for setting up a brand-new (unprovisioned) module.
+    let provision = qdl::provision::ensure_provision_xml(&soc, &board_slug).await;
+    if let qdl::provision::ProvisionSource::Unavailable(reason) = &provision {
+        log_warn!("qdl_operations", "Provision XML unavailable: {}", reason);
+    }
+
+    let image_path = PathBuf::from(&image_path);
+    // qdlrs is synchronous, so run the flash off the async runtime.
+    let result = tokio::task::spawn_blocking(move || {
+        qdl::flash::qdl_flash_ufs(
+            &image_path,
+            &loader_path,
+            serial,
+            autoconfig,
+            provision,
+            flash_state,
+        )
+    })
+    .await
+    .map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("Error sending data") || msg.contains("Error receiving data") {
+            "[QDL_DISCONNECTED]".to_string()
+        } else if msg.contains("cancelled") || msg.contains("Interrupted") {
+            "[QDL_CANCELLED]".to_string()
+        } else {
+            format!("[QDL_ERROR] {}", msg)
+        }
+    })?;
+
+    match &result {
+        Ok(()) => log_info!("qdl_operations", "QDL UFS flash completed successfully"),
+        Err(e) => log_error!("qdl_operations", "QDL UFS flash failed: {}", e),
+    }
+    result
+}
+
+/// EDL-entry method ("button" or "jumper") for a board's on-screen hint, or null if unknown.
+#[tauri::command]
+pub async fn get_qdl_edl_entry(board_slug: String) -> Option<String> {
+    qdl::boards::find(&board_slug).map(|b| b.edl_entry.as_str().to_string())
 }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -28,6 +28,9 @@ pub mod urls {
 
     /// Base URL for vendor logos (api.armbian.com/api/v1/images/vendors/{size}/{slug}.png)
     pub const VENDOR_IMAGES_BASE: &str = "https://api.armbian.com/api/v1/images/vendors/480/";
+
+    /// Base URL for QDL firehose loaders, by SoC family ({base}{family}/prog_firehose_ddr.elf).
+    pub const QCOMBIN_LOADER_BASE: &str = "https://raw.githubusercontent.com/armbian/qcombin/main/";
 }
 
 /// Download and decompression settings

--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -29,19 +29,11 @@ fn is_flashable_format(format: &str) -> bool {
     matches!(format, "sd" | "block" | "qdl")
 }
 
-/// UFS images are raw provisioning images (no GPT) for QDL/firehose, not a block
-/// device — writing one to an SD card yields a non-booting card. Drop until QDL UFS lands.
-fn is_writable_storage(storage: Option<&str>) -> bool {
-    !matches!(storage, Some(s) if s.eq_ignore_ascii_case("ufs"))
-}
-
 /// Map a list of API images to frontend-facing ImageInfo, sorted by promoted first then release
 pub fn map_images(api_images: Vec<ApiImage>) -> Vec<ImageInfo> {
     let mut images: Vec<ImageInfo> = api_images
         .iter()
-        .filter(|api| {
-            is_flashable_format(&api.format) && is_writable_storage(api.storage.as_deref())
-        })
+        .filter(|api| is_flashable_format(&api.format))
         .map(map_image)
         .collect();
 
@@ -72,6 +64,7 @@ fn map_image(api: &ApiImage) -> ImageInfo {
         build_date: api.download.updated_at.clone(),
         stability: api.stability.clone(),
         format: api.format.clone(),
+        storage: api.storage.clone(),
         companions: api
             .companions
             .iter()

--- a/src-tauri/src/images/models.rs
+++ b/src-tauri/src/images/models.rs
@@ -159,6 +159,8 @@ pub struct ImageInfo {
     pub stability: String,
     /// Image format: "sd" (block), "qdl" (Qualcomm EDL), "rootfs", "qemu", "hyperv"
     pub format: String,
+    /// Storage target ("ufs" = raw Firehose write to internal UFS via QDL), else None.
+    pub storage: Option<String>,
     /// Companion files (bootloaders, firmware, etc.)
     #[serde(default)]
     pub companions: Vec<CompanionInfo>,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -162,6 +162,8 @@ fn main() {
             commands::progress::get_flash_progress,
             commands::qdl_operations::get_qdl_devices,
             commands::qdl_operations::flash_qdl_image,
+            commands::qdl_operations::flash_qdl_ufs_image,
+            commands::qdl_operations::get_qdl_edl_entry,
             commands::custom_image::select_custom_image,
             commands::custom_image::check_needs_decompression,
             commands::custom_image::decompress_custom_image,

--- a/src-tauri/src/qdl/boards.rs
+++ b/src-tauri/src/qdl/boards.rs
@@ -1,0 +1,59 @@
+//! Single source of truth for per-board QDL/EDL facts (loader family, UFS provisioning, EDL hint).
+
+#[derive(Clone, Copy)]
+pub enum EdlEntry {
+    Button,
+    Jumper,
+}
+
+impl EdlEntry {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EdlEntry::Button => "button",
+            EdlEntry::Jumper => "jumper",
+        }
+    }
+}
+
+pub struct QdlBoard {
+    /// Matched case-insensitively as a substring of the board slug.
+    pub slug_token: &'static str,
+    /// Used to resolve the loader family when the Armbian API leaves `soc` null.
+    pub soc: &'static str,
+    pub provision_rel: Option<&'static str>,
+    pub edl_entry: EdlEntry,
+}
+
+pub const QDL_BOARDS: &[QdlBoard] = &[
+    QdlBoard {
+        slug_token: "dragon-q6a",
+        soc: "QCS6490",
+        provision_rel: Some("radxa-dragon-q6a/provision_ufs31_lun0_only.xml"),
+        edl_entry: EdlEntry::Button,
+    },
+    QdlBoard {
+        slug_token: "arduino-uno-q",
+        soc: "QRB2210",
+        provision_rel: None,
+        edl_entry: EdlEntry::Jumper,
+    },
+];
+
+pub fn find(board_slug: &str) -> Option<&'static QdlBoard> {
+    let slug = board_slug.to_lowercase();
+    QDL_BOARDS.iter().find(|b| slug.contains(b.slug_token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_board_by_slug_substring() {
+        let b = find("radxa-dragon-q6a").expect("dragon-q6a is registered");
+        assert_eq!(b.soc, "QCS6490");
+        assert_eq!(b.edl_entry.as_str(), "button");
+        assert!(b.provision_rel.is_some());
+        assert!(find("orangepi-5").is_none());
+    }
+}

--- a/src-tauri/src/qdl/flash.rs
+++ b/src-tauri/src/qdl/flash.rs
@@ -11,14 +11,17 @@ use indexmap::IndexMap;
 use qdl::parsers::{firehose_parser_ack_nak, firehose_parser_configure_response};
 use qdl::sahara::{sahara_run, SaharaMode};
 use qdl::types::{
-    FirehoseConfiguration, FirehoseResetMode, FirehoseStorageType, QdlBackend, QdlChan, QdlDevice,
+    FirehoseConfiguration, FirehoseResetMode, QdlBackend, QdlChan, QdlDevice, QdlReadWrite,
 };
 use qdl::{
     firehose_configure, firehose_patch, firehose_program_storage, firehose_read, firehose_reset,
-    setup_target_device,
+    firehose_write_getack, setup_target_device,
 };
 use xmltree::{Element, XMLNode};
 
+use super::extract::FIREHOSE_ELF;
+use super::provision::ProvisionSource;
+use super::QdlStorage;
 use crate::flash::FlashState;
 use crate::{log_info, log_warn};
 
@@ -32,117 +35,9 @@ pub fn qdl_flash(
 ) -> Result<(), String> {
     state.qdl.is_active.store(true, Ordering::SeqCst);
 
-    // --- Stage 1: Connect to EDL device ---
-    update_qdl_stage(&state, "connecting");
-    log_info!("qdl::flash", "Connecting to EDL device...");
-
-    let rw_channel = setup_target_device(QdlBackend::Usb, serial, None).map_err(|e| {
-        let msg = e.to_string();
-        if msg.contains("errno 13")
-            || msg.contains("Permission denied")
-            || msg.contains("Access denied")
-        {
-            "[QDL_PERMISSION_DENIED]".to_string()
-        } else {
-            format!("[QDL_CONNECTION_FAILED] {}", msg)
-        }
-    })?;
-
-    let mut device = QdlDevice {
-        rw: rw_channel,
-        fh_cfg: FirehoseConfiguration {
-            storage_type: FirehoseStorageType::Emmc,
-            storage_sector_size: 512,
-            bypass_storage: false,
-            backend: QdlBackend::Usb,
-            skip_firehose_log: true,
-            verbose_firehose: false,
-            ..Default::default()
-        },
-        reset_on_drop: false,
-    };
-
-    log_info!("qdl::flash", "Connected to EDL device");
-
-    // --- Stage 2: Sahara handshake and firehose programmer upload ---
-    check_cancelled(&state)?;
-    update_qdl_stage(&state, "sahara");
-    log_info!("qdl::flash", "Starting Sahara handshake...");
-
-    // Step 2a: Read chip serial number (initiates the Sahara HELLO exchange)
-    let sn = sahara_run(
-        &mut device,
-        SaharaMode::Command,
-        Some(qdl::sahara::SaharaCmdModeCmd::ReadSerialNum),
-        &mut [],
-        vec![],
-        false,
-    )
-    .map_err(|e| {
-        format!(
-            "Sahara handshake failed: {}. Ensure the device is in EDL mode.",
-            e
-        )
-    })?;
-
-    if sn.len() >= 4 {
-        let serial = u32::from_le_bytes([sn[0], sn[1], sn[2], sn[3]]);
-        log_info!("qdl::flash", "Chip serial number: {:#x}", serial);
-    }
-
-    // Step 2b: Read OEM key hash (best effort, result unused).
-    let _ = sahara_run(
-        &mut device,
-        SaharaMode::Command,
-        Some(qdl::sahara::SaharaCmdModeCmd::ReadOemKeyHash),
-        &mut [],
-        vec![],
-        false,
-    );
-
-    // Step 2c: Upload firehose programmer
-    log_info!("qdl::flash", "Uploading firehose programmer...");
-
-    let elf_path = flash_dir.join("prog_firehose_ddr.elf");
-    let elf_data =
-        fs::read(&elf_path).map_err(|e| format!("Failed to read firehose programmer: {}", e))?;
-
-    sahara_run(
-        &mut device,
-        SaharaMode::WaitingForImage,
-        None,
-        &mut [elf_data],
-        vec![],
-        false,
-    )
-    .map_err(|e| {
-        format!(
-            "Sahara upload failed: {}. The firehose programmer may be incompatible.",
-            e
-        )
-    })?;
-
-    log_info!("qdl::flash", "Firehose programmer uploaded successfully");
-
-    // Once the programmer is up, dropping the device should reset it.
-    device.reset_on_drop = true;
-
-    // --- Stage 3: Configure Firehose ---
-    check_cancelled(&state)?;
-    update_qdl_stage(&state, "configuring");
-    log_info!("qdl::flash", "Configuring Firehose protocol...");
-
-    firehose_read(&mut device, firehose_parser_ack_nak)
-        .map_err(|e| format!("Failed to read firehose welcome: {}", e))?;
-
-    firehose_configure(&mut device, false)
-        .map_err(|e| format!("Firehose configuration failed: {}", e))?;
-
-    // Configure response may renegotiate buffer sizes.
-    firehose_read(&mut device, firehose_parser_configure_response)
-        .map_err(|e| format!("Firehose configure handshake failed: {}", e))?;
-
-    log_info!("qdl::flash", "Firehose configured successfully");
+    // Connect, upload the firehose programmer, and configure Firehose (eMMC defaults).
+    let elf_path = flash_dir.join(FIREHOSE_ELF);
+    let mut device = connect_and_configure(serial, &elf_path, QdlStorage::Emmc, &state)?;
 
     // --- Autoconfig injection (still within the "configuring" stage) ---
     // Inject first-boot preset into the extracted ext4 rootfs blob IN PLACE before Firehose reads it.
@@ -183,6 +78,278 @@ pub fn qdl_flash(
     log_info!("qdl::flash", "QDL flash completed successfully");
 
     Ok(())
+}
+
+/// Flash a whole `.img` to UFS via one raw Firehose write to LUN 0 sector 0
+/// (`edl-ng --memory ufs write-sector 0 <img>` equivalent).
+pub fn qdl_flash_ufs(
+    image_path: &Path,
+    elf_path: &Path,
+    serial: Option<String>,
+    autoconfig: Option<crate::autoconfig::AutoconfigConfig>,
+    provision: ProvisionSource,
+    state: Arc<FlashState>,
+) -> Result<(), String> {
+    state.qdl.is_active.store(true, Ordering::SeqCst);
+
+    let mut device = connect_and_configure(serial, elf_path, QdlStorage::Ufs, &state)?;
+
+    // Inject before Firehose reads the image; detect.rs handles the 4096-byte UFS sectors.
+    if let Some(cfg) = autoconfig.as_ref() {
+        check_cancelled(&state)?;
+        crate::autoconfig::inject_into_image(image_path, cfg)
+            .map_err(|e| format!("[QDL_AUTOCONFIG_FAILED] {}", e))?;
+    }
+
+    check_cancelled(&state)?;
+    update_qdl_stage(&state, "firehose");
+
+    let sector_size = QdlStorage::Ufs.sector_size();
+    let img_len = fs::metadata(image_path)
+        .map_err(|e| format!("Failed to stat image: {}", e))?
+        .len();
+    let num_sectors = raw_num_sectors(img_len, sector_size);
+    let total_bytes = num_sectors as u64 * sector_size as u64;
+    state.qdl.partitions_total.store(1, Ordering::SeqCst);
+    state.total_bytes.store(total_bytes, Ordering::SeqCst);
+    {
+        let mut stage = state.qdl.stage.lock().unwrap_or_else(|p| p.into_inner());
+        *stage = "partition:system".to_string();
+    }
+
+    log_info!(
+        "qdl::flash",
+        "Writing {} bytes ({} sectors) to UFS...",
+        img_len,
+        num_sectors
+    );
+
+    if let Err(e) = write_ufs_image(&mut device, image_path, num_sectors, &state) {
+        // A program NAK on UFS means the module has no LUN 0 (a brand-new, unprovisioned module):
+        // provision it in-session, then retry the write once.
+        if e.contains("NAKed") {
+            match provision {
+                ProvisionSource::Ready(prov) => {
+                    check_cancelled(&state)?;
+                    update_qdl_stage(&state, "provisioning");
+                    provision_ufs(&mut device, &prov)?;
+                    check_cancelled(&state)?;
+                    update_qdl_stage(&state, "firehose");
+                    state.written_bytes.store(0, Ordering::SeqCst);
+                    write_ufs_image(&mut device, image_path, num_sectors, &state).map_err(|e| {
+                        format!("Failed to write UFS image after provisioning: {e}")
+                    })?;
+                }
+                ProvisionSource::Absent => {
+                    return Err(format!("Failed to write UFS image: {e} The UFS module is likely unprovisioned (no LUN 0); provision it before flashing."));
+                }
+                ProvisionSource::Unavailable(reason) => {
+                    return Err(format!("Failed to write UFS image: {e} The module looks unprovisioned and auto-provisioning could not run: {reason}"));
+                }
+            }
+        } else {
+            return Err(format!("Failed to write UFS image: {e}"));
+        }
+    }
+
+    state.qdl.partitions_written.store(1, Ordering::SeqCst);
+    state.written_bytes.store(total_bytes, Ordering::SeqCst);
+
+    update_qdl_stage(&state, "resetting");
+    log_info!("qdl::flash", "Resetting device...");
+    device.reset_on_drop = false;
+    firehose_reset(&mut device, &FirehoseResetMode::Reset, 0)
+        .map_err(|e| {
+            log_warn!("qdl::flash", "Device reset failed (non-fatal): {}", e);
+        })
+        .ok();
+
+    update_qdl_stage(&state, "complete");
+    log_info!("qdl::flash", "QDL UFS flash completed successfully");
+    Ok(())
+}
+
+/// Sectors needed to hold `len` bytes, rounding the final partial sector up.
+fn raw_num_sectors(len: u64, sector: usize) -> usize {
+    len.div_ceil(sector as u64) as usize
+}
+
+/// Stream `image_path` to UFS LUN 0 sector 0. Returns the raw qdlrs error string on failure
+/// so the caller can branch on a `<program>` NAK (unprovisioned module).
+fn write_ufs_image(
+    device: &mut QdlDevice<dyn QdlReadWrite>,
+    image_path: &Path,
+    num_sectors: usize,
+    state: &Arc<FlashState>,
+) -> Result<(), String> {
+    let file = fs::File::open(image_path).map_err(|e| format!("Failed to open image: {}", e))?;
+    let progress_state = state.clone();
+    let mut reader = ProgressReader::new(file, state.clone(), move |bytes_transferred| {
+        progress_state
+            .written_bytes
+            .store(bytes_transferred, Ordering::SeqCst);
+    });
+    firehose_program_storage(device, &mut reader, "system", num_sectors, 0, 0, "0")
+        .map_err(|e| e.to_string())
+}
+
+/// Provision a blank UFS module in the current session from the qcombin `<ufs>` descriptor.
+/// Configures with SkipStorageInit (a blank module has no LUN to init), sends each `<ufs>`
+/// command, then re-initialises storage so the new LUN 0 is writable.
+fn provision_ufs(device: &mut QdlDevice<dyn QdlReadWrite>, xml_path: &Path) -> Result<(), String> {
+    let commands = super::provision::parse_ufs_commands(xml_path)?;
+    log_info!(
+        "qdl::flash",
+        "Provisioning UFS ({} commands) from {}",
+        commands.len(),
+        xml_path.display()
+    );
+
+    firehose_configure(device, true).map_err(|e| format!("Provision configure failed: {e}"))?;
+    firehose_read(device, firehose_parser_ack_nak)
+        .map_err(|e| format!("Provision configure handshake failed: {e}"))?;
+
+    for cmd in &commands {
+        let mut packet = build_ufs_packet(cmd);
+        firehose_write_getack(
+            device,
+            &mut packet,
+            "send UFS provisioning command".to_string(),
+        )
+        .map_err(|e| format!("UFS provisioning command failed: {e}"))?;
+    }
+
+    firehose_configure(device, false)
+        .map_err(|e| format!("Post-provision configure failed: {e}"))?;
+    firehose_read(device, firehose_parser_ack_nak)
+        .map_err(|e| format!("Post-provision configure handshake failed: {e}"))?;
+
+    log_info!("qdl::flash", "UFS provisioning complete");
+    Ok(())
+}
+
+/// Serialise one `<ufs>` command into a Firehose `<data>` packet.
+fn build_ufs_packet(attrs: &[(String, String)]) -> Vec<u8> {
+    let mut s = String::from("<?xml version=\"1.0\" ?>\n<data>\n  <ufs");
+    for (k, v) in attrs {
+        s.push(' ');
+        s.push_str(k);
+        s.push_str("=\"");
+        s.push_str(v);
+        s.push('"');
+    }
+    s.push_str(" />\n</data>");
+    s.into_bytes()
+}
+
+/// Connect, upload the firehose programmer from `elf_path`, and configure Firehose for `storage`.
+fn connect_and_configure(
+    serial: Option<String>,
+    elf_path: &Path,
+    storage: QdlStorage,
+    state: &Arc<FlashState>,
+) -> Result<QdlDevice<dyn QdlReadWrite>, String> {
+    update_qdl_stage(state, "connecting");
+    log_info!("qdl::flash", "Connecting to EDL device...");
+
+    let rw_channel = setup_target_device(QdlBackend::Usb, serial, None).map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("errno 13")
+            || msg.contains("Permission denied")
+            || msg.contains("Access denied")
+        {
+            "[QDL_PERMISSION_DENIED]".to_string()
+        } else {
+            format!("[QDL_CONNECTION_FAILED] {}", msg)
+        }
+    })?;
+
+    let mut device = QdlDevice {
+        rw: rw_channel,
+        fh_cfg: FirehoseConfiguration {
+            storage_type: storage.firehose_type(),
+            storage_sector_size: storage.sector_size(),
+            bypass_storage: false,
+            backend: QdlBackend::Usb,
+            skip_firehose_log: true,
+            verbose_firehose: false,
+            ..Default::default()
+        },
+        reset_on_drop: false,
+    };
+    log_info!("qdl::flash", "Connected to EDL device");
+
+    check_cancelled(state)?;
+    update_qdl_stage(state, "sahara");
+    log_info!("qdl::flash", "Starting Sahara handshake...");
+
+    // Reading the chip serial number initiates the Sahara HELLO exchange.
+    let sn = sahara_run(
+        &mut device,
+        SaharaMode::Command,
+        Some(qdl::sahara::SaharaCmdModeCmd::ReadSerialNum),
+        &mut [],
+        vec![],
+        false,
+    )
+    .map_err(|e| {
+        format!(
+            "Sahara handshake failed: {}. Ensure the device is in EDL mode.",
+            e
+        )
+    })?;
+    if sn.len() >= 4 {
+        log_info!(
+            "qdl::flash",
+            "Chip serial number: {:#x}",
+            u32::from_le_bytes([sn[0], sn[1], sn[2], sn[3]])
+        );
+    }
+
+    // OEM key hash (best effort, result unused).
+    let _ = sahara_run(
+        &mut device,
+        SaharaMode::Command,
+        Some(qdl::sahara::SaharaCmdModeCmd::ReadOemKeyHash),
+        &mut [],
+        vec![],
+        false,
+    );
+
+    log_info!("qdl::flash", "Uploading firehose programmer...");
+    let elf_data =
+        fs::read(elf_path).map_err(|e| format!("Failed to read firehose programmer: {}", e))?;
+    sahara_run(
+        &mut device,
+        SaharaMode::WaitingForImage,
+        None,
+        &mut [elf_data],
+        vec![],
+        false,
+    )
+    .map_err(|e| {
+        format!(
+            "Sahara upload failed: {}. The firehose programmer may be incompatible.",
+            e
+        )
+    })?;
+    log_info!("qdl::flash", "Firehose programmer uploaded successfully");
+
+    // Once the programmer is up, dropping the device should reset it.
+    device.reset_on_drop = true;
+
+    check_cancelled(state)?;
+    update_qdl_stage(state, "configuring");
+    log_info!("qdl::flash", "Configuring Firehose protocol...");
+    firehose_read(&mut device, firehose_parser_ack_nak)
+        .map_err(|e| format!("Failed to read firehose welcome: {}", e))?;
+    firehose_configure(&mut device, false)
+        .map_err(|e| format!("Firehose configuration failed: {}", e))?;
+    firehose_read(&mut device, firehose_parser_configure_response)
+        .map_err(|e| format!("Firehose configure handshake failed: {}", e))?;
+    log_info!("qdl::flash", "Firehose configured successfully");
+
+    Ok(device)
 }
 
 /// Offset of the ext4 superblock magic within a bare ext4 image, and its value.
@@ -667,5 +834,19 @@ impl<R: Read, F: FnMut(u64)> Read for ProgressReader<R, F> {
         self.bytes_transferred += buf.len() as u64;
         (self.on_progress)(self.bytes_transferred);
         Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_num_sectors_rounds_up() {
+        assert_eq!(raw_num_sectors(0, 4096), 0);
+        assert_eq!(raw_num_sectors(4096, 4096), 1);
+        assert_eq!(raw_num_sectors(4097, 4096), 2);
+        assert_eq!(raw_num_sectors(8192, 4096), 2);
+        assert_eq!(raw_num_sectors(512, 512), 1);
     }
 }

--- a/src-tauri/src/qdl/loader.rs
+++ b/src-tauri/src/qdl/loader.rs
@@ -1,0 +1,123 @@
+//! Fetches and caches the Qualcomm firehose loader (`prog_firehose_ddr.elf`) for a
+//! board's SoC family from the armbian/qcombin repo, used to flash QDL/EDL devices.
+
+use std::path::{Path, PathBuf};
+
+use crate::config;
+use crate::log_info;
+use crate::qdl::extract::FIREHOSE_ELF;
+use crate::utils::{fetch_to_file, loaders_dir};
+
+const MIN_LOADER_SIZE: u64 = 64 * 1024;
+const ELF_MAGIC: &[u8; 4] = b"\x7fELF";
+
+// SoC token -> qcombin family, matched case-insensitively by substring.
+const SOC_FAMILY: &[(&str, &str)] = &[
+    ("QCS6490", "Kodiak"),
+    ("QCM6490", "Kodiak"),
+    ("QCS5430", "Kodiak"),
+    ("QCM5430", "Kodiak"),
+    ("SC7280", "Kodiak"),
+    ("SM7325", "Kodiak"),
+    ("QRB2210", "Agatti"),
+    ("QCM2290", "Agatti"),
+    ("QCS2290", "Agatti"),
+];
+
+pub fn family_for_soc(soc: &str) -> Option<&'static str> {
+    let soc = soc.to_uppercase();
+    SOC_FAMILY
+        .iter()
+        .find(|(token, _)| soc.contains(token))
+        .map(|(_, family)| *family)
+}
+
+pub fn resolve_family(soc: &str, board_slug: &str) -> Option<&'static str> {
+    family_for_soc(soc)
+        .or_else(|| super::boards::find(board_slug).and_then(|b| family_for_soc(b.soc)))
+}
+
+/// Ensure the board's firehose loader is cached locally, downloading from qcombin on a miss.
+pub async fn ensure_loader(soc: &str, board_slug: &str) -> Result<PathBuf, String> {
+    let family = resolve_family(soc, board_slug).ok_or_else(|| {
+        format!("No QDL firehose loader known for SoC '{soc}' / board '{board_slug}'")
+    })?;
+
+    let path = loaders_dir().join(family).join(FIREHOSE_ELF);
+    if path.exists() && validate_loader(&path).is_ok() {
+        log_info!(
+            "qdl::loader",
+            "Using cached firehose loader: {}",
+            path.display()
+        );
+        return Ok(path);
+    }
+
+    let url = format!(
+        "{}{}/{}",
+        config::urls::QCOMBIN_LOADER_BASE,
+        family,
+        FIREHOSE_ELF
+    );
+    log_info!("qdl::loader", "Downloading firehose loader: {}", url);
+    fetch_to_file(&url, &path, validate_loader_bytes).await?;
+    log_info!(
+        "qdl::loader",
+        "Cached firehose loader at {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+/// Validate an on-disk loader: ELF magic + a plausible minimum size.
+fn validate_loader(path: &Path) -> Result<(), String> {
+    use std::io::Read;
+    let len = std::fs::metadata(path).map_err(|e| e.to_string())?.len();
+    if len < MIN_LOADER_SIZE {
+        return Err(format!("loader too small ({len} bytes)"));
+    }
+    let mut head = [0u8; 4];
+    std::fs::File::open(path)
+        .and_then(|mut f| f.read_exact(&mut head))
+        .map_err(|e| e.to_string())?;
+    if &head != ELF_MAGIC {
+        return Err("not an ELF file".into());
+    }
+    Ok(())
+}
+
+/// Validate freshly downloaded loader bytes before installing them.
+fn validate_loader_bytes(bytes: &[u8]) -> Result<(), String> {
+    if (bytes.len() as u64) < MIN_LOADER_SIZE {
+        return Err(format!(
+            "downloaded loader too small ({} bytes)",
+            bytes.len()
+        ));
+    }
+    if !bytes.starts_with(ELF_MAGIC) {
+        return Err("downloaded loader is not an ELF file".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_known_socs_case_insensitively() {
+        assert_eq!(family_for_soc("QCS6490"), Some("Kodiak"));
+        assert_eq!(family_for_soc("qcm6490"), Some("Kodiak"));
+        assert_eq!(family_for_soc("Qualcomm QCS6490"), Some("Kodiak"));
+        assert_eq!(family_for_soc("QRB2210"), Some("Agatti"));
+        assert_eq!(family_for_soc("rk3588"), None);
+        assert_eq!(family_for_soc(""), None);
+    }
+
+    #[test]
+    fn resolves_family_from_board_slug_when_soc_missing() {
+        assert_eq!(resolve_family("", "radxa-dragon-q6a"), Some("Kodiak"));
+        assert_eq!(resolve_family("QCS6490", ""), Some("Kodiak"));
+        assert_eq!(resolve_family("", "orangepi-5"), None);
+    }
+}

--- a/src-tauri/src/qdl/mod.rs
+++ b/src-tauri/src/qdl/mod.rs
@@ -1,9 +1,12 @@
 //! QDL (Qualcomm Device Loader): flashing for boards using Qualcomm EDL (Emergency Download) mode instead of block-device
 //! writes. Uses the Sahara protocol to upload a firehose programmer, then the Firehose protocol to program partitions.
 
+pub mod boards;
 pub mod detect;
 pub mod extract;
 pub mod flash;
+pub mod loader;
+pub mod provision;
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +15,32 @@ pub const QUALCOMM_VID: u16 = 0x05c6;
 
 /// USB Product ID for EDL (Emergency Download) mode
 pub const EDL_PID: u16 = 0x9008;
+
+pub const SECTOR_SIZE_EMMC: usize = 512;
+pub const SECTOR_SIZE_UFS: usize = 4096;
+
+/// Storage backend for a QDL flash, mapping to its Firehose storage type and sector size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QdlStorage {
+    Emmc,
+    Ufs,
+}
+
+impl QdlStorage {
+    pub fn sector_size(self) -> usize {
+        match self {
+            QdlStorage::Emmc => SECTOR_SIZE_EMMC,
+            QdlStorage::Ufs => SECTOR_SIZE_UFS,
+        }
+    }
+
+    pub fn firehose_type(self) -> qdl::types::FirehoseStorageType {
+        match self {
+            QdlStorage::Emmc => qdl::types::FirehoseStorageType::Emmc,
+            QdlStorage::Ufs => qdl::types::FirehoseStorageType::Ufs,
+        }
+    }
+}
 
 /// Represents a Qualcomm device in EDL mode detected via USB
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/qdl/provision.rs
+++ b/src-tauri/src/qdl/provision.rs
@@ -1,0 +1,96 @@
+//! Fetches the per-board UFS provisioning descriptor from qcombin and parses its `<ufs>`
+//! commands, used to set up a brand-new (unprovisioned) UFS module before the first write.
+
+use std::path::PathBuf;
+
+use xmltree::{Element, XMLNode};
+
+use crate::config;
+use crate::log_info;
+use crate::qdl::loader::resolve_family;
+use crate::utils::{fetch_to_file, loaders_dir};
+
+fn provision_rel_path(board_slug: &str) -> Option<&'static str> {
+    crate::qdl::boards::find(board_slug).and_then(|b| b.provision_rel)
+}
+
+/// Where a board's UFS provisioning descriptor stands: ready, not declared, or expected but unreachable.
+pub enum ProvisionSource {
+    Ready(PathBuf),
+    /// Board declares no descriptor; a blank module must be provisioned manually.
+    Absent,
+    /// Board declares a descriptor but it couldn't be fetched (404/network); carries the reason.
+    Unavailable(String),
+}
+
+/// Locate the board's UFS provisioning XML, downloading it to the cache on first use.
+pub async fn ensure_provision_xml(soc: &str, board_slug: &str) -> ProvisionSource {
+    let (Some(family), Some(rel)) = (
+        resolve_family(soc, board_slug),
+        provision_rel_path(board_slug),
+    ) else {
+        return ProvisionSource::Absent;
+    };
+    match fetch_provision_xml(family, rel).await {
+        Ok(path) => ProvisionSource::Ready(path),
+        Err(e) => ProvisionSource::Unavailable(e),
+    }
+}
+
+async fn fetch_provision_xml(family: &str, rel: &str) -> Result<PathBuf, String> {
+    let path = loaders_dir().join(family).join(rel);
+    if path.exists() {
+        log_info!(
+            "qdl::provision",
+            "Using cached provision XML: {}",
+            path.display()
+        );
+        return Ok(path);
+    }
+    let url = format!("{}{}/{}", config::urls::QCOMBIN_LOADER_BASE, family, rel);
+    log_info!("qdl::provision", "Downloading provision XML: {}", url);
+    fetch_to_file(&url, &path, validate_provision_bytes).await?;
+    Ok(path)
+}
+
+fn validate_provision_bytes(bytes: &[u8]) -> Result<(), String> {
+    if !bytes.windows(5).any(|w| w == b"<ufs ") {
+        return Err("Downloaded provision XML has no <ufs> commands".to_string());
+    }
+    Ok(())
+}
+
+/// Parse the `<ufs>` elements (in document order) into per-command attribute lists.
+pub fn parse_ufs_commands(path: &std::path::Path) -> Result<Vec<Vec<(String, String)>>, String> {
+    let data = std::fs::read(path).map_err(|e| format!("Failed to read provision XML: {e}"))?;
+    let root =
+        Element::parse(&data[..]).map_err(|e| format!("Failed to parse provision XML: {e}"))?;
+
+    let commands: Vec<Vec<(String, String)>> = root
+        .children
+        .into_iter()
+        .filter_map(|node| match node {
+            XMLNode::Element(e) if e.name == "ufs" => Some(e.attributes.into_iter().collect()),
+            _ => None,
+        })
+        .collect();
+
+    if commands.is_empty() {
+        return Err("Provision XML contains no <ufs> commands".to_string());
+    }
+    Ok(commands)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_provision_path_by_slug() {
+        assert_eq!(
+            provision_rel_path("radxa-dragon-q6a"),
+            Some("radxa-dragon-q6a/provision_ufs31_lun0_only.xml")
+        );
+        assert_eq!(provision_rel_path("orangepi-5"), None);
+    }
+}

--- a/src-tauri/src/utils/http.rs
+++ b/src-tauri/src/utils/http.rs
@@ -1,5 +1,8 @@
 //! Shared builder for reqwest clients with the standard user agent.
 
+use std::path::Path;
+use std::time::Duration;
+
 use crate::config;
 
 /// Build a reqwest client with the standard user agent and the given timeout.
@@ -10,4 +13,36 @@ pub fn build_client(timeout: std::time::Duration) -> Result<reqwest::Client, Str
         .timeout(timeout)
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))
+}
+
+/// Fetch `url` and install the body at `dest` atomically (temp + rename), after `validate`
+/// accepts the bytes. Creates parent dirs. Backs the QDL loader/provision caches.
+pub async fn fetch_to_file(
+    url: &str,
+    dest: &Path,
+    validate: impl Fn(&[u8]) -> Result<(), String>,
+) -> Result<(), String> {
+    let client = build_client(Duration::from_secs(config::http::REQUEST_TIMEOUT_SECS))?;
+    let bytes = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch {url}: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Download error for {url}: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read body from {url}: {e}"))?;
+
+    validate(&bytes)?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create cache dir: {e}"))?;
+    }
+    let tmp = dest.with_extension("part");
+    std::fs::write(&tmp, &bytes).map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+    std::fs::rename(&tmp, dest).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("Failed to install {}: {e}", dest.display())
+    })
 }

--- a/src-tauri/src/utils/system.rs
+++ b/src-tauri/src/utils/system.rs
@@ -64,6 +64,11 @@ pub fn qdl_temp_dir() -> PathBuf {
     app_cache_dir().join("qdl-temp")
 }
 
+/// Directory caching downloaded QDL firehose loaders, keyed by SoC family.
+pub fn loaders_dir() -> PathBuf {
+    app_cache_dir().join("loaders")
+}
+
 /// Directory holding session log files.
 pub fn logs_dir() -> PathBuf {
     app_cache_dir().join("logs")

--- a/src/components/flash/FlashProgress.tsx
+++ b/src/components/flash/FlashProgress.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { HardDrive, Disc, FileImage } from 'lucide-react';
+import { HardDrive, Usb, Disc, FileImage } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { BoardInfo, ImageInfo, BlockDevice, AutoconfigConfig } from '../../types';
+import { isEdlImage } from '../../types';
 import { getOsName } from '../../assets/os-logos';
 import { getMonoLogo } from '../../config/mono-logos';
 import { distroBlock } from '../../utils/distroTheme';
@@ -45,7 +46,7 @@ export function FlashProgress({
     handleBack,
     handleShaWarningConfirm,
     handleShaWarningCancel,
-  } = useFlashOperation({ image, device, autoconfig, onBack });
+  } = useFlashOperation({ image, device, soc: board.soc, boardSlug: board.slug, autoconfig, onBack });
 
   useEffect(() => {
     getCachedBoardImage(board.slug)
@@ -67,6 +68,7 @@ export function FlashProgress({
   const isError = stage === 'error';
   const isComplete = stage === 'complete';
   const isCustomIcon = image.is_custom && board.slug === 'custom';
+  const isEdl = isEdlImage(image);
 
   // Glow brightness tracks progress; indeterminate stages sit at mid-glow.
   const glowProgress = isComplete ? 100 : isIndeterminate ? 50 : progress;
@@ -124,7 +126,7 @@ export function FlashProgress({
                   <MarqueeText text={getImageDisplayText()} className="os-badge-text" />
                 </div>
                 <div className="flash-device-row">
-                  <HardDrive size={16} />
+                  {isEdl ? <Usb size={16} /> : <HardDrive size={16} />}
                   <MarqueeText text={device.model || device.name} className="flash-device-name" />
                   {device.size_formatted && <span className="flash-device-size">{device.size_formatted}</span>}
                 </div>
@@ -156,7 +158,7 @@ export function FlashProgress({
 
               {isComplete && (
                 <p className="flash-success-hint">
-                  {image.format === 'qdl'
+                  {isEdl
                     ? t('flash.successHintQdl')
                     : image.is_custom
                       ? t('flash.successHintCustom')

--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -4,12 +4,13 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ErrorDisplay, DeviceIcon, getDeviceBadge, BoardImage, MarqueeText } from '../shared';
-import type { BlockDevice, AutoconfigProfile, AutoconfigProfilesChangedDetail } from '../../types';
-import { getBlockDevices, getQdlDevices } from '../../hooks/useTauri';
+import type { BlockDevice, AutoconfigProfile, AutoconfigProfilesChangedDetail, FlashMethod } from '../../types';
+import { isEdlMethod } from '../../types';
+import { getBlockDevices, getQdlDevices, getQdlEdlEntry } from '../../hooks/useTauri';
 import { getAutoconfigProfiles } from '../../hooks/useSettings';
 import { useAsyncData } from '../../hooks/useAsyncData';
 import { useSkeletonLoading } from '../../hooks/useSkeletonLoading';
-import { POLLING, UI, EVENTS } from '../../config';
+import { POLLING, UI, EVENTS, qdlInstructionsKey } from '../../config';
 import { getDeviceColors } from '../../config/deviceColors';
 import { getDeviceType, devicesChanged, sortDevices, qdlToBlockDevice } from '../../utils/deviceUtils';
 
@@ -25,8 +26,10 @@ interface DevicePanelProps {
   onCancel: () => void;
   /** The picked device; when set, the panel shows the confirm summary. */
   selectedDevice: BlockDevice | null;
-  /** Flash method for the selected image ("block" or "qdl"). */
-  flashMethod?: string;
+  /** Flash method for the selected image ("block", "qdl", or "qdl-ufs"). */
+  flashMethod?: FlashMethod;
+  /** Selected board slug, used to pick the right EDL-entry hint (button vs jumper). */
+  boardSlug?: string;
   /** Upstream selections (manufacturer/board/OS) shown in the confirm summary. */
   summary?: { label: string; value: string }[];
   /** Cached board photo shown at the top of the confirm summary. */
@@ -42,6 +45,7 @@ export function DevicePanel({
   onCancel,
   selectedDevice,
   flashMethod,
+  boardSlug,
   summary = [],
   boardImage,
   supportsAutoconfig = true,
@@ -52,7 +56,14 @@ export function DevicePanel({
   const prevDevicesRef = useRef<BlockDevice[] | null>(null);
   const [devices, setDevices] = useState<BlockDevice[]>([]);
 
-  const isQdlMode = flashMethod === 'qdl';
+  // Both QDL (TAR) and UFS images flash over EDL, so they share device detection (getQdlDevices).
+  const isQdlMode = isEdlMethod(flashMethod);
+
+  // EDL-entry method (button vs jumper) comes from the backend board registry.
+  const { data: edlEntry } = useAsyncData<string | null>(
+    () => (isQdlMode && boardSlug ? getQdlEdlEntry(boardSlug) : Promise.resolve(null)),
+    [isQdlMode, boardSlug]
+  );
   // Autoconfig profiles apply to Armbian images (both sd/.img.xz and QDL); hidden for generic custom images.
   const showAutoconfig = supportsAutoconfig;
 
@@ -206,7 +217,7 @@ export function DevicePanel({
                 ))}
                 {/* Target device as a label/value row, consistent with the rows above. */}
                 <li className="device-summary__target">
-                  <span className="device-summary__label">{t('home.storage')}</span>
+                  <span className="device-summary__label">{t(isQdlMode ? 'home.device' : 'home.storage')}</span>
                   <span className="device-summary__targetinfo">
                     <MarqueeText
                       text={selectedDevice.model || selectedDevice.name}
@@ -338,7 +349,7 @@ export function DevicePanel({
               <span className="device-empty__icon">{isQdlMode ? <Cpu size={30} /> : <Usb size={30} />}</span>
               <p className="device-empty__title">{isQdlMode ? t('device.qdlNotFound') : t('modal.noDevices')}</p>
               <p className="device-empty__hint">
-                {isQdlMode ? t('device.qdlInstructions') : t('modal.insertDevice')}
+                {isQdlMode ? t(qdlInstructionsKey(edlEntry)) : t('modal.insertDevice')}
               </p>
               {refreshButton}
             </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import armbianLogoWhite from '../../assets/armbian-logo-white.png';
 import armbianLogoBlack from '../../assets/armbian-logo-black.png';
 import type { BoardInfo, ImageInfo, BlockDevice, SelectionStep, Manufacturer } from '../../types';
+import { isEdlImage } from '../../types';
 import { UpdateModal } from '../shared';
 import { SettingsButton } from '../settings';
 
@@ -45,16 +46,19 @@ export function Header({
   // Detected-board images show all 4 steps; generic .img files show 2.
   const hasDetectedBoard = selectedBoard && selectedBoard.slug !== 'custom' && selectedBoard.slug !== 'cached';
   const isGenericCustom = isCustomImage && !hasDetectedBoard;
+  // EDL targets are USB devices in download mode, not storage drives.
+  const isEdl = !!selectedImage && isEdlImage(selectedImage);
+  const targetLabel = t(isEdl ? 'header.stepDevice' : 'header.stepStorage');
   const steps = isGenericCustom
     ? [
         { key: 'image' as SelectionStep, label: t('header.stepImage'), completed: !!selectedImage },
-        { key: 'device' as SelectionStep, label: t('header.stepStorage'), completed: !!selectedDevice },
+        { key: 'device' as SelectionStep, label: targetLabel, completed: !!selectedDevice },
       ]
     : [
         { key: 'manufacturer' as SelectionStep, label: t('header.stepManufacturer'), completed: !!selectedManufacturer },
         { key: 'board' as SelectionStep, label: t('header.stepBoard'), completed: !!selectedBoard },
         { key: 'image' as SelectionStep, label: t('header.stepOs'), completed: !!selectedImage },
-        { key: 'device' as SelectionStep, label: t('header.stepStorage'), completed: !!selectedDevice },
+        { key: 'device' as SelectionStep, label: targetLabel, completed: !!selectedDevice },
       ];
 
   function handleLogoClick() {

--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, type ReactNode, type ComponentType } from 'react';
-import { Factory, Cpu, Database, HardDrive, FolderOpen, Archive, Check, ArrowRight, Lock, WifiOff } from 'lucide-react';
+import { Factory, Cpu, Database, HardDrive, Usb, FolderOpen, Archive, Check, ArrowRight, Lock, WifiOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { getCachedBoardImage } from '../../hooks/useTauri';
 import { IMAGE_VARIANT } from '../../config';
 import { isDetectedBoard, formatImageIdentity } from '../../utils';
 import type { BoardInfo, ImageInfo, BlockDevice, Manufacturer } from '../../types';
+import { deriveFlashMethod, isEdlImage } from '../../types';
 import { MarqueeText, MotdTip, BoardImage, UpdateEntry } from '../shared';
 import { ManufacturerPanel } from './ManufacturerPanel';
 import { BoardPanel } from './BoardPanel';
@@ -101,6 +102,16 @@ function osTitle(image: ImageInfo, t: (key: string) => string): ReactNode {
 }
 function osMeta(image: ImageInfo, t: (key: string) => string): ReactNode {
   return formatImageIdentity(image, t).meta;
+}
+
+/** Last step is a USB "device" (icon + wording) for EDL/QDL images, a "storage" drive otherwise. */
+function deviceStepMeta(
+  image: ImageInfo | null,
+  t: (key: string) => string
+): { icon: ComponentType<{ size?: number }>; label: string; cta: string } {
+  return image && isEdlImage(image)
+    ? { icon: Usb, label: t('home.device'), cta: t('home.chooseDevice') }
+    : { icon: HardDrive, label: t('home.storage'), cta: t('home.chooseStorage') };
 }
 
 /** Step sidebar + focus panel that highlights the active step and previews the board. */
@@ -239,6 +250,7 @@ export function HomePage({
     <MarqueeText text={selectedDevice.model || selectedDevice.name} className="val-text" />
   ) : undefined;
   const deviceMeta = selectedDevice ? selectedDevice.size_formatted : null;
+  const dStep = deviceStepMeta(selectedImage, t);
 
   // Upstream selections shown in the inline storage confirm summary.
   const deviceSummary = [
@@ -250,7 +262,8 @@ export function HomePage({
   // Inline storage panel; it picks list vs. confirm view from `selectedDevice`.
   const renderDevicePanel = () => (
     <DevicePanel
-      flashMethod={selectedImage?.format}
+      flashMethod={selectedImage ? deriveFlashMethod(selectedImage) : undefined}
+      boardSlug={selectedBoard?.slug}
       summary={deviceSummary}
       boardImage={boardImage}
       selectedDevice={selectedDevice}
@@ -316,9 +329,9 @@ export function HomePage({
       {
         key: 'device',
         index: 2,
-        icon: HardDrive,
-        label: t('home.storage'),
-        cta: t('home.chooseStorage'),
+        icon: dStep.icon,
+        label: dStep.label,
+        cta: dStep.cta,
         value: deviceValue,
         meta: deviceMeta,
         state: selectedDevice ? 'done' : 'active',
@@ -380,9 +393,9 @@ export function HomePage({
       {
         key: 'device',
         index: 4,
-        icon: HardDrive,
-        label: t('home.storage'),
-        cta: t('home.chooseStorage'),
+        icon: dStep.icon,
+        label: dStep.label,
+        cta: dStep.cta,
         value: deviceValue,
         meta: deviceMeta,
         state: selectedDevice ? 'done' : 'active',
@@ -452,9 +465,9 @@ export function HomePage({
     {
       key: 'device',
       index: 4,
-      icon: HardDrive,
-      label: t('home.storage'),
-      cta: t('home.chooseStorage'),
+      icon: dStep.icon,
+      label: dStep.label,
+      cta: dStep.cta,
       value: deviceValue,
       meta: deviceMeta,
       state: !selectedImage ? 'locked' : selectedDevice ? 'done' : 'active',

--- a/src/components/layout/OsPanel.tsx
+++ b/src/components/layout/OsPanel.tsx
@@ -208,6 +208,12 @@ export function OsPanel({ board, onSelect }: OsPanelProps) {
                 {kernelBadge?.label ?? image.kernel_branch}{image.kernel_version ? ` ${image.kernel_version}` : ''}
               </span>
             )}
+            {image.storage?.toLowerCase() === 'ufs' && (
+              <span className="dl-card__kernel">
+                <span className="dl-dot" style={{ background: '#f59e0b' }} />
+                UFS
+              </span>
+            )}
             <span className="dl-card__footright">
               {isCached(image) && <CachedBadge label={t('modal.cachedTooltip')} light />}
               {!!image.file_size && (
@@ -260,6 +266,7 @@ export function OsPanel({ board, onSelect }: OsPanelProps) {
                   label={`${kernelBadge.label}${image.kernel_version ? ` ${image.kernel_version}` : ''}`}
                 />
               )}
+              {image.storage?.toLowerCase() === 'ufs' && <SoftBadge color="#f59e0b" label="UFS" />}
             </div>
             <div className="os-card__footright">
               {isCached(image) && <CachedBadge label={t('modal.cachedTooltip')} />}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,3 +52,4 @@ export {
 // Image filters
 export { isTrunkImage, IMAGE_FILTER_PREDICATES, FILTER_BUTTONS, categoryOf } from './imageFilters';
 export type { OsCategory } from './imageFilters';
+export { qdlInstructionsKey } from './qdlBoards';

--- a/src/config/qdlBoards.ts
+++ b/src/config/qdlBoards.ts
@@ -1,0 +1,4 @@
+/** i18n key for the EDL-entry hint, from the backend-resolved method (defaults to jumper). */
+export function qdlInstructionsKey(edlEntry?: string | null): string {
+  return edlEntry === 'button' ? 'device.qdlInstructionsButton' : 'device.qdlInstructions';
+}

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -3,11 +3,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ImageInfo, BlockDevice, AutoconfigConfig } from '../types';
+import { FLASH_METHOD, deriveFlashMethod, isEdlMethod } from '../types';
 import { PHASE_ORDER, type FlashStage, type FlashPhase } from '../components/flash/FlashStageIcon';
 import {
   downloadImage,
   flashImage,
   flashQdlImage,
+  flashQdlUfsImage,
   getDownloadProgress,
   getFlashProgress,
   cancelOperation,
@@ -32,6 +34,10 @@ import { isShaUnavailableError, translateFlashError } from '../utils/errorUtils'
 interface UseFlashOperationProps {
   image: ImageInfo;
   device: BlockDevice;
+  /** Board SoC, used to select the firehose loader for UFS (QDL) flashing. */
+  soc?: string;
+  /** Board slug, the fallback loader key when the API leaves `soc` null. */
+  boardSlug?: string;
   /** Opt-in autoconfig profile config written into the image on first boot; null when none. */
   autoconfig?: AutoconfigConfig | null;
   onBack: () => void;
@@ -81,6 +87,8 @@ function buildPhases(opts: { download: boolean; prepare: boolean; verify: boolea
 export function useFlashOperation({
   image,
   device,
+  soc,
+  boardSlug,
   autoconfig,
   onBack,
 }: UseFlashOperationProps): UseFlashOperationReturn {
@@ -161,13 +169,18 @@ export function useFlashOperation({
     [t]
   );
 
-  /** Whether the current image uses QDL (Qualcomm EDL) flashing */
-  const isQdlMode = image.format === 'qdl';
+  // Write path: TAR-based QDL ('qdl'), raw UFS over QDL ('qdl-ufs'), or block dd.
+  const flashMethod = deriveFlashMethod(image);
+  // isQdlMode == the TAR path specifically (extract + rawprogram, no download cleanup).
+  const isQdlMode = flashMethod === FLASH_METHOD.QDL;
+  const isUfsMode = flashMethod === FLASH_METHOD.QDL_UFS;
+  // Both flash an EDL device, so they share device handling, auth skip, and no block verify.
+  const isEdlFlash = isEdlMethod(flashMethod);
 
   /** Check the device is connected; trigger the disconnect handler and return false if not */
   const checkDeviceOrDisconnect = useCallback(async (): Promise<boolean> => {
     try {
-      if (isQdlMode) {
+      if (isEdlFlash) {
         const qdlDevices = await getQdlDevices();
         if (qdlDevices.length === 0) {
           await handleDeviceDisconnectedInternal();
@@ -185,7 +198,7 @@ export function useFlashOperation({
     }
     return true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [device.path, isQdlMode]);
+  }, [device.path, isEdlFlash]);
 
   /** Handle device disconnection during operations */
   const handleDeviceDisconnectedInternal = useCallback(async () => {
@@ -213,7 +226,7 @@ export function useFlashOperation({
   // Monitor device connection during active operations.
   // QDL flash stages are excluded: the USB device is busy/resets during Sahara/Firehose (expected).
   useEffect(() => {
-    const activeStages: FlashStage[] = isQdlMode
+    const activeStages: FlashStage[] = isEdlFlash
       ? ['downloading', 'verifying_sha', 'decompressing']
       : ['downloading', 'verifying_sha', 'decompressing',
          'flashing', 'verifying'];
@@ -234,7 +247,7 @@ export function useFlashOperation({
         deviceMonitorRef.current = null;
       }
     };
-  }, [stage, device.path, isQdlMode, handleDeviceDisconnectedInternal, checkDeviceOrDisconnect]);
+  }, [stage, device.path, isEdlFlash, handleDeviceDisconnectedInternal, checkDeviceOrDisconnect]);
 
   /** Handle custom image flow (decompress if needed, then flash) */
   async function handleCustomImage(customPath: string) {
@@ -339,7 +352,7 @@ export function useFlashOperation({
         const prog = await getFlashProgress();
 
         if (prog.is_qdl_mode && prog.qdl_stage) {
-          if (prog.qdl_stage === 'sahara' || prog.qdl_stage === 'connecting' || prog.qdl_stage === 'configuring') {
+          if (prog.qdl_stage === 'sahara' || prog.qdl_stage === 'connecting' || prog.qdl_stage === 'configuring' || prog.qdl_stage === 'provisioning') {
             setStage('qdl_sahara');
           } else if (prog.qdl_stage.startsWith('partition:') || prog.qdl_stage === 'firehose' || prog.qdl_stage === 'patching') {
             setStage('qdl_firehose');
@@ -386,12 +399,20 @@ export function useFlashOperation({
     }, POLLING.FLASH_PROGRESS);
 
     try {
-      if (isQdlMode) {
+      // Pass autoconfig only when a profile was selected (else undefined = unchanged)
+      if (isUfsMode) {
+        // UFS path: decompressed .img → Sahara → raw Firehose write to UFS
+        await flashQdlUfsImage(
+          path,
+          soc ?? '',
+          boardSlug ?? '',
+          undefined,
+          autoconfigRef.current ?? undefined
+        );
+      } else if (isQdlMode) {
         // QDL path: TAR archive → extract → Sahara → Firehose
-        // Pass autoconfig only when a profile was selected (else undefined = unchanged)
         await flashQdlImage(path, undefined, autoconfigRef.current ?? undefined);
       } else {
-        // Pass autoconfig only when a profile was selected (else undefined = unchanged)
         await flashImage(path, device.path, !skipVerifyRef.current, autoconfigRef.current ?? undefined);
       }
       if (intervalRef.current) clearInterval(intervalRef.current);
@@ -453,8 +474,8 @@ export function useFlashOperation({
         skipVerifyRef.current = false;
       }
 
-      // QDL skips block-device authorization (USB access handled by OS)
-      if (!isQdlMode) {
+      // EDL (QDL/UFS) skips block-device authorization (USB access handled by OS)
+      if (!isEdlFlash) {
         const authorized = await requestWriteAuthorization(device.path);
         if (!authorized) {
           failFlash(t('error.authCancelled'));
@@ -482,7 +503,7 @@ export function useFlashOperation({
           buildPhases({
             download: !cached,
             prepare: isQdlMode || (!cached && isCompressedImage(image.direct_url)),
-            verify: !isQdlMode && !skipVerifyRef.current,
+            verify: !isEdlFlash && !skipVerifyRef.current,
           })
         );
         startDownload();
@@ -514,8 +535,8 @@ export function useFlashOperation({
     try {
       await cancelOperation();
       if (intervalRef.current) clearInterval(intervalRef.current);
-      // QDL: stay put so the blocking flash command can detect cancel and clean up
-      if (isQdlMode) {
+      // EDL: stay put so the blocking flash command can detect cancel and clean up
+      if (isEdlFlash) {
         setStage('authorizing');
         setProgress(0);
         setError(t('flash.cancel'));
@@ -546,9 +567,10 @@ export function useFlashOperation({
     shownErrorRef.current = null;
 
     if (imagePath) {
-      // QDL: skip block-device authorization (USB access handled by OS)
-      if (isQdlMode) {
-        setPhases(buildPhases({ download: false, prepare: true, verify: false }));
+      // EDL: skip block-device authorization (USB access handled by OS). The TAR path
+      // re-extracts (prepare), but a UFS .img is already decompressed and ready.
+      if (isEdlFlash) {
+        setPhases(buildPhases({ download: false, prepare: isQdlMode, verify: false }));
         startFlash(imagePath);
         return;
       }

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -229,7 +229,24 @@ export async function flashQdlImage(
   return invoke('flash_qdl_image', { tarPath, serial, autoconfig });
 }
 
+/** Flash a decompressed UFS .img to an EDL device via a raw Firehose write; the loader is
+ * resolved from `soc`, then `boardSlug` (the API leaves `soc` null for these boards). */
+export async function flashQdlUfsImage(
+  imagePath: string,
+  soc: string,
+  boardSlug: string,
+  serial?: string,
+  autoconfig?: AutoconfigConfig | null
+): Promise<void> {
+  return invoke('flash_qdl_ufs_image', { imagePath, soc, boardSlug, serial, autoconfig });
+}
+
 /** Check whether a TAR file is a QDL flash archive (has rawprogram0.xml + firehose ELF) */
 export async function checkIsQdlImage(imagePath: string): Promise<boolean> {
   return invoke('check_is_qdl_image', { imagePath });
+}
+
+/** EDL-entry method ("button" or "jumper") for a board, or null when unknown */
+export async function getQdlEdlEntry(boardSlug: string): Promise<string | null> {
+  return invoke('get_qdl_edl_entry', { boardSlug });
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Board wählen",
     "chooseOs": "OS wählen",
     "chooseStorage": "Speicher wählen",
+    "device": "Gerät",
+    "chooseDevice": "Gerät wählen",
     "welcomeHeading": "Willkommen bei Armbian Imager",
     "welcomeIntro": "Wähle dein Board und ein Image. Wir laden es herunter, schreiben es auf deine SD-Karte oder deinen USB-Stick und prüfen es für dich.",
     "startNow": "Jetzt starten",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Systemlaufwerke ausblenden",
     "locked": "Gesperrt",
     "qdlNotFound": "Kein EDL-Gerät gefunden. Versetze dein Board in den EDL-Modus und verbinde es per USB.",
-    "qdlInstructions": "Setze den Jumper auf die JCTL-Pins und schließe dann das USB-C-Kabel an."
+    "qdlInstructions": "Setze den Jumper auf die JCTL-Pins und schließe dann das USB-C-Kabel an.",
+    "qdlInstructionsButton": "Halte beim Einschalten die EDL-Taste gedrückt und schließe dann das USB-Kabel an."
   },
   "header": {
     "stepManufacturer": "Hersteller",
     "stepBoard": "Board",
     "stepOs": "OS",
     "stepStorage": "Speicher",
+    "stepDevice": "Gerät",
     "stepImage": "Image",
     "resetTooltip": "Neu starten",
     "stepTooltip": "{{step}} ändern"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Choose board",
     "chooseOs": "Choose OS",
     "chooseStorage": "Choose storage",
+    "device": "Device",
+    "chooseDevice": "Choose device",
     "welcomeHeading": "Welcome to Armbian Imager",
     "welcomeIntro": "Pick your board and an image. We'll download it, write it to your SD card or USB drive, and verify it for you.",
     "startNow": "Start now",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Hide system drives",
     "locked": "Locked",
     "qdlNotFound": "No EDL device found. Put your board in EDL mode and connect via USB.",
-    "qdlInstructions": "Place the jumper on the JCTL pins, then connect the USB-C cable."
+    "qdlInstructions": "Place the jumper on the JCTL pins, then connect the USB-C cable.",
+    "qdlInstructionsButton": "Hold the EDL button while powering on, then connect the USB cable."
   },
   "header": {
     "stepManufacturer": "Manufacturer",
     "stepBoard": "Board",
     "stepOs": "OS",
     "stepStorage": "Storage",
+    "stepDevice": "Device",
     "stepImage": "Image",
     "resetTooltip": "Start over",
     "stepTooltip": "Change {{step}}"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Elegir placa",
     "chooseOs": "Elegir SO",
     "chooseStorage": "Elegir almacenamiento",
+    "device": "Dispositivo",
+    "chooseDevice": "Elegir dispositivo",
     "welcomeHeading": "Bienvenido a Armbian Imager",
     "welcomeIntro": "Elige tu placa y una imagen. Nosotros la descargamos, la escribimos en tu tarjeta SD o unidad USB y la verificamos por ti.",
     "startNow": "Empezar ahora",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Ocultar unidades del sistema",
     "locked": "Bloqueado",
     "qdlNotFound": "No se encontró ningún dispositivo EDL. Pon tu placa en modo EDL y conéctala por USB.",
-    "qdlInstructions": "Coloca el jumper en los pines JCTL y conecta el cable USB-C."
+    "qdlInstructions": "Coloca el jumper en los pines JCTL y conecta el cable USB-C.",
+    "qdlInstructionsButton": "Mantén pulsado el botón EDL al encender y conecta el cable USB."
   },
   "header": {
     "stepManufacturer": "Fabricante",
     "stepBoard": "Placa",
     "stepOs": "SO",
     "stepStorage": "Almacenamiento",
+    "stepDevice": "Dispositivo",
     "stepImage": "Imagen",
     "resetTooltip": "Empezar de nuevo",
     "stepTooltip": "Cambiar {{step}}"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Choisir une carte",
     "chooseOs": "Choisir un OS",
     "chooseStorage": "Choisir un stockage",
+    "device": "Appareil",
+    "chooseDevice": "Choisir un appareil",
     "welcomeHeading": "Bienvenue dans Armbian Imager",
     "welcomeIntro": "Choisissez votre carte et une image. On s'occupe de la télécharger, de l'écrire sur votre carte SD ou clé USB et de la vérifier.",
     "startNow": "Commencer",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Masquer les disques système",
     "locked": "Verrouillé",
     "qdlNotFound": "Aucun appareil EDL trouvé. Mettez votre carte en mode EDL et connectez-la en USB.",
-    "qdlInstructions": "Placez le cavalier sur les broches JCTL, puis connectez le câble USB-C."
+    "qdlInstructions": "Placez le cavalier sur les broches JCTL, puis connectez le câble USB-C.",
+    "qdlInstructionsButton": "Maintenez le bouton EDL enfoncé à la mise sous tension, puis branchez le câble USB."
   },
   "header": {
     "stepManufacturer": "Fabricant",
     "stepBoard": "Carte",
     "stepOs": "OS",
     "stepStorage": "Stockage",
+    "stepDevice": "Appareil",
     "stepImage": "Image",
     "resetTooltip": "Recommencer",
     "stepTooltip": "Modifier {{step}}"

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Odaberite ploču",
     "chooseOs": "Odaberite OS",
     "chooseStorage": "Odaberite pohranu",
+    "device": "Uređaj",
+    "chooseDevice": "Odaberite uređaj",
     "welcomeHeading": "Dobro došli u Armbian Imager",
     "welcomeIntro": "Odaberite ploču i sliku. Mi ćemo je preuzeti, zapisati na vašu SD karticu ili USB pogon i provjeriti.",
     "startNow": "Započnite",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Sakrij sistemske diskove",
     "locked": "Zaključano",
     "qdlNotFound": "EDL uređaj nije pronađen. Postavite ploču u EDL način rada i spojite je putem USB-a.",
-    "qdlInstructions": "Postavite jumper na JCTL pinove, zatim spojite USB-C kabel."
+    "qdlInstructions": "Postavite jumper na JCTL pinove, zatim spojite USB-C kabel.",
+    "qdlInstructionsButton": "Držite tipku EDL pri uključivanju, zatim spojite USB kabel."
   },
   "header": {
     "stepManufacturer": "Proizvođač",
     "stepBoard": "Ploča",
     "stepOs": "OS",
     "stepStorage": "Pohrana",
+    "stepDevice": "Uređaj",
     "stepImage": "Slika",
     "resetTooltip": "Počni ispočetka",
     "stepTooltip": "Promijeni {{step}}"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Scegli la scheda",
     "chooseOs": "Scegli il sistema operativo",
     "chooseStorage": "Scegli l'archiviazione",
+    "device": "Dispositivo",
+    "chooseDevice": "Scegli il dispositivo",
     "welcomeHeading": "Benvenuto in Armbian Imager",
     "welcomeIntro": "Scegli la scheda e l'immagine. Pensiamo noi a scaricarla, scriverla sulla tua scheda SD o chiavetta USB e verificarla.",
     "startNow": "Inizia ora",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Nascondi dischi di sistema",
     "locked": "Bloccato",
     "qdlNotFound": "Nessun dispositivo EDL trovato. Metti la scheda in modalità EDL e collegala via USB.",
-    "qdlInstructions": "Posiziona il jumper sui pin JCTL, poi collega il cavo USB-C."
+    "qdlInstructions": "Posiziona il jumper sui pin JCTL, poi collega il cavo USB-C.",
+    "qdlInstructionsButton": "Tieni premuto il pulsante EDL all'accensione, poi collega il cavo USB."
   },
   "header": {
     "stepManufacturer": "Produttore",
     "stepBoard": "Scheda",
     "stepOs": "SO",
     "stepStorage": "Archiviazione",
+    "stepDevice": "Dispositivo",
     "stepImage": "Immagine",
     "resetTooltip": "Ricomincia",
     "stepTooltip": "Cambia {{step}}"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -8,6 +8,8 @@
     "chooseBoard": "ボードを選択",
     "chooseOs": "OSを選択",
     "chooseStorage": "ストレージを選択",
+    "device": "デバイス",
+    "chooseDevice": "デバイスを選択",
     "welcomeHeading": "Armbian Imager へようこそ",
     "welcomeIntro": "ボードとイメージを選ぶだけ。ダウンロードからSDカードやUSBドライブへの書き込み、検証まで私たちにお任せください。",
     "startNow": "今すぐ始める",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "システムドライブを非表示",
     "locked": "ロック中",
     "qdlNotFound": "EDLデバイスが見つかりません。ボードをEDLモードにして、USBで接続してください。",
-    "qdlInstructions": "JCTLピンにジャンパーを取り付けてから、USB-Cケーブルを接続してください。"
+    "qdlInstructions": "JCTLピンにジャンパーを取り付けてから、USB-Cケーブルを接続してください。",
+    "qdlInstructionsButton": "EDLボタンを押しながら電源を入れ、USBケーブルを接続してください。"
   },
   "header": {
     "stepManufacturer": "メーカー",
     "stepBoard": "ボード",
     "stepOs": "OS",
     "stepStorage": "ストレージ",
+    "stepDevice": "デバイス",
     "stepImage": "イメージ",
     "resetTooltip": "最初からやり直す",
     "stepTooltip": "{{step}}を変更"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -8,6 +8,8 @@
     "chooseBoard": "보드 선택",
     "chooseOs": "OS 선택",
     "chooseStorage": "저장 장치 선택",
+    "device": "장치",
+    "chooseDevice": "장치 선택",
     "welcomeHeading": "Armbian Imager에 오신 것을 환영합니다",
     "welcomeIntro": "보드와 이미지를 고르기만 하세요. 다운로드부터 SD 카드나 USB 드라이브 기록, 검사까지 저희가 알아서 처리합니다.",
     "startNow": "지금 시작",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "시스템 드라이브 숨기기",
     "locked": "잠김",
     "qdlNotFound": "EDL 장치를 찾을 수 없습니다. 보드를 EDL 모드로 전환한 뒤 USB로 연결하세요.",
-    "qdlInstructions": "JCTL 핀에 점퍼를 끼운 다음 USB-C 케이블을 연결하세요."
+    "qdlInstructions": "JCTL 핀에 점퍼를 끼운 다음 USB-C 케이블을 연결하세요.",
+    "qdlInstructionsButton": "전원을 켤 때 EDL 버튼을 누른 채로 USB 케이블을 연결하세요."
   },
   "header": {
     "stepManufacturer": "제조사",
     "stepBoard": "보드",
     "stepOs": "OS",
     "stepStorage": "저장 장치",
+    "stepDevice": "장치",
     "stepImage": "이미지",
     "resetTooltip": "처음부터 다시",
     "stepTooltip": "{{step}} 변경"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Kies board",
     "chooseOs": "Kies OS",
     "chooseStorage": "Kies opslag",
+    "device": "Apparaat",
+    "chooseDevice": "Kies apparaat",
     "welcomeHeading": "Welkom bij Armbian Imager",
     "welcomeIntro": "Kies je board en een image. Wij downloaden het, schrijven het naar je SD-kaart of USB-stick en controleren het voor je.",
     "startNow": "Nu beginnen",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Systeemstations verbergen",
     "locked": "Vergrendeld",
     "qdlNotFound": "Geen EDL-apparaat gevonden. Zet je board in EDL-modus en sluit het aan via USB.",
-    "qdlInstructions": "Plaats de jumper op de JCTL-pinnen en sluit de USB-C-kabel aan."
+    "qdlInstructions": "Plaats de jumper op de JCTL-pinnen en sluit de USB-C-kabel aan.",
+    "qdlInstructionsButton": "Houd de EDL-knop ingedrukt bij het inschakelen en sluit dan de USB-kabel aan."
   },
   "header": {
     "stepManufacturer": "Fabrikant",
     "stepBoard": "Board",
     "stepOs": "OS",
     "stepStorage": "Opslag",
+    "stepDevice": "Apparaat",
     "stepImage": "Image",
     "resetTooltip": "Opnieuw beginnen",
     "stepTooltip": "{{step}} wijzigen"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Wybierz płytkę",
     "chooseOs": "Wybierz OS",
     "chooseStorage": "Wybierz pamięć",
+    "device": "Urządzenie",
+    "chooseDevice": "Wybierz urządzenie",
     "welcomeHeading": "Witamy w Armbian Imager",
     "welcomeIntro": "Wybierz płytkę i obraz. My pobierzemy go, zapiszemy na karcie SD lub dysku USB i sprawdzimy za Ciebie.",
     "startNow": "Rozpocznij teraz",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Ukryj dyski systemowe",
     "locked": "Zablokowane",
     "qdlNotFound": "Nie znaleziono urządzenia EDL. Przełącz płytkę w tryb EDL i podłącz przez USB.",
-    "qdlInstructions": "Umieść zworkę na pinach JCTL, a następnie podłącz kabel USB-C."
+    "qdlInstructions": "Umieść zworkę na pinach JCTL, a następnie podłącz kabel USB-C.",
+    "qdlInstructionsButton": "Przytrzymaj przycisk EDL podczas włączania, a następnie podłącz kabel USB."
   },
   "header": {
     "stepManufacturer": "Producent",
     "stepBoard": "Płytka",
     "stepOs": "OS",
     "stepStorage": "Pamięć",
+    "stepDevice": "Urządzenie",
     "stepImage": "Obraz",
     "resetTooltip": "Zacznij od nowa",
     "stepTooltip": "Zmień {{step}}"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Escolher placa",
     "chooseOs": "Escolher SO",
     "chooseStorage": "Escolher armazenamento",
+    "device": "Dispositivo",
+    "chooseDevice": "Escolher dispositivo",
     "welcomeHeading": "Bem-vindo ao Armbian Imager",
     "welcomeIntro": "Escolha sua placa e uma imagem. A gente baixa, grava no seu cartão SD ou pendrive USB e verifica para você.",
     "startNow": "Começar agora",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Ocultar unidades do sistema",
     "locked": "Bloqueado",
     "qdlNotFound": "Nenhum dispositivo EDL encontrado. Coloque sua placa em modo EDL e conecte-a via USB.",
-    "qdlInstructions": "Coloque o jumper nos pinos JCTL e conecte o cabo USB-C."
+    "qdlInstructions": "Coloque o jumper nos pinos JCTL e conecte o cabo USB-C.",
+    "qdlInstructionsButton": "Mantenha o botão EDL pressionado ao ligar e conecte o cabo USB."
   },
   "header": {
     "stepManufacturer": "Fabricante",
     "stepBoard": "Placa",
     "stepOs": "SO",
     "stepStorage": "Armazenamento",
+    "stepDevice": "Dispositivo",
     "stepImage": "Imagem",
     "resetTooltip": "Recomeçar",
     "stepTooltip": "Alterar {{step}}"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Escolher placa",
     "chooseOs": "Escolher SO",
     "chooseStorage": "Escolher armazenamento",
+    "device": "Dispositivo",
+    "chooseDevice": "Escolher dispositivo",
     "welcomeHeading": "Bem-vindo ao Armbian Imager",
     "welcomeIntro": "Escolha a sua placa e uma imagem. Nós tratamos de a transferir, gravar no seu cartão SD ou unidade USB e verificá-la.",
     "startNow": "Começar agora",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Ocultar unidades do sistema",
     "locked": "Bloqueado",
     "qdlNotFound": "Nenhum dispositivo EDL encontrado. Coloque a placa em modo EDL e ligue por USB.",
-    "qdlInstructions": "Coloque o jumper nos pinos JCTL e ligue o cabo USB-C."
+    "qdlInstructions": "Coloque o jumper nos pinos JCTL e ligue o cabo USB-C.",
+    "qdlInstructionsButton": "Mantém o botão EDL premido ao ligar e liga o cabo USB."
   },
   "header": {
     "stepManufacturer": "Fabricante",
     "stepBoard": "Placa",
     "stepOs": "SO",
     "stepStorage": "Armazenamento",
+    "stepDevice": "Dispositivo",
     "stepImage": "Imagem",
     "resetTooltip": "Reiniciar",
     "stepTooltip": "Alterar {{step}}"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Выбрать плату",
     "chooseOs": "Выбрать ОС",
     "chooseStorage": "Выбрать хранилище",
+    "device": "Устройство",
+    "chooseDevice": "Выбрать устройство",
     "welcomeHeading": "Добро пожаловать в Armbian Imager",
     "welcomeIntro": "Выберите плату и образ. Мы сами загрузим его, запишем на SD-карту или USB-накопитель и проверим.",
     "startNow": "Начать",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Скрыть системные диски",
     "locked": "Заблокировано",
     "qdlNotFound": "Устройство EDL не найдено. Переведите плату в режим EDL и подключите её по USB.",
-    "qdlInstructions": "Установите перемычку на контакты JCTL, затем подключите кабель USB-C."
+    "qdlInstructions": "Установите перемычку на контакты JCTL, затем подключите кабель USB-C.",
+    "qdlInstructionsButton": "Удерживайте кнопку EDL при включении, затем подключите кабель USB."
   },
   "header": {
     "stepManufacturer": "Производитель",
     "stepBoard": "Плата",
     "stepOs": "ОС",
     "stepStorage": "Хранилище",
+    "stepDevice": "Устройство",
     "stepImage": "Образ",
     "resetTooltip": "Начать сначала",
     "stepTooltip": "Изменить {{step}}"

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Izberi ploščo",
     "chooseOs": "Izberi OS",
     "chooseStorage": "Izberi shrambo",
+    "device": "Naprava",
+    "chooseDevice": "Izberi napravo",
     "welcomeHeading": "Dobrodošli v Armbian Imager",
     "welcomeIntro": "Izberite ploščo in sliko. Mi jo prenesemo, zapišemo na kartico SD ali pogon USB in preverimo namesto vas.",
     "startNow": "Začni zdaj",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Skrij sistemske pogone",
     "locked": "Zaklenjeno",
     "qdlNotFound": "Naprava EDL ni bila najdena. Vključite ploščo v način EDL in jo povežite prek USB.",
-    "qdlInstructions": "Namestite mostiček na pine JCTL, nato priključite kabel USB-C."
+    "qdlInstructions": "Namestite mostiček na pine JCTL, nato priključite kabel USB-C.",
+    "qdlInstructionsButton": "Med vklopom držite gumb EDL, nato priključite kabel USB."
   },
   "header": {
     "stepManufacturer": "Proizvajalec",
     "stepBoard": "Plošča",
     "stepOs": "OS",
     "stepStorage": "Shramba",
+    "stepDevice": "Naprava",
     "stepImage": "Slika",
     "resetTooltip": "Začni znova",
     "stepTooltip": "Spremeni {{step}}"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Välj kort",
     "chooseOs": "Välj operativsystem",
     "chooseStorage": "Välj lagring",
+    "device": "Enhet",
+    "chooseDevice": "Välj enhet",
     "welcomeHeading": "Välkommen till Armbian Imager",
     "welcomeIntro": "Välj ditt kort och en avbildning. Vi laddar ner den, skriver den till ditt SD-kort eller USB-minne och kontrollerar den åt dig.",
     "startNow": "Kom igång",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Dölj systemenheter",
     "locked": "Låst",
     "qdlNotFound": "Ingen EDL-enhet hittades. Sätt ditt kort i EDL-läge och anslut via USB.",
-    "qdlInstructions": "Placera bygeln på JCTL-pinnarna och anslut sedan USB-C-kabeln."
+    "qdlInstructions": "Placera bygeln på JCTL-pinnarna och anslut sedan USB-C-kabeln.",
+    "qdlInstructionsButton": "Håll EDL-knappen intryckt vid start och anslut sedan USB-kabeln."
   },
   "header": {
     "stepManufacturer": "Tillverkare",
     "stepBoard": "Kort",
     "stepOs": "OS",
     "stepStorage": "Lagring",
+    "stepDevice": "Enhet",
     "stepImage": "Avbildning",
     "resetTooltip": "Börja om",
     "stepTooltip": "Ändra {{step}}"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Kart seç",
     "chooseOs": "İşletim sistemi seç",
     "chooseStorage": "Depolama seç",
+    "device": "Cihaz",
+    "chooseDevice": "Cihaz seç",
     "welcomeHeading": "Armbian Imager'a hoş geldiniz",
     "welcomeIntro": "Kartınızı ve bir imajı seçin. İndirme, SD karta ya da USB sürücüye yazma ve doğrulama işini biz hallederiz.",
     "startNow": "Hemen başla",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Sistem sürücülerini gizle",
     "locked": "Kilitli",
     "qdlNotFound": "EDL cihazı bulunamadı. Kartınızı EDL moduna alın ve USB ile bağlayın.",
-    "qdlInstructions": "JCTL pinlerine jumper yerleştirin, ardından USB-C kablosunu bağlayın."
+    "qdlInstructions": "JCTL pinlerine jumper yerleştirin, ardından USB-C kablosunu bağlayın.",
+    "qdlInstructionsButton": "Açılışta EDL düğmesini basılı tutun, ardından USB kablosunu bağlayın."
   },
   "header": {
     "stepManufacturer": "Üretici",
     "stepBoard": "Kart",
     "stepOs": "İS",
     "stepStorage": "Depolama",
+    "stepDevice": "Cihaz",
     "stepImage": "İmaj",
     "resetTooltip": "Yeniden başla",
     "stepTooltip": "{{step}} değiştir"

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -8,6 +8,8 @@
     "chooseBoard": "Обрати плату",
     "chooseOs": "Обрати ОС",
     "chooseStorage": "Обрати сховище",
+    "device": "Пристрій",
+    "chooseDevice": "Обрати пристрій",
     "welcomeHeading": "Ласкаво просимо до Armbian Imager",
     "welcomeIntro": "Виберіть плату та образ. Ми самі завантажимо його, запишемо на SD-картку чи USB-накопичувач і перевіримо.",
     "startNow": "Почати",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "Приховати системні диски",
     "locked": "Заблоковано",
     "qdlNotFound": "Пристрій EDL не знайдено. Переведіть плату в режим EDL та підключіть через USB.",
-    "qdlInstructions": "Встановіть перемичку на контакти JCTL, потім підключіть кабель USB-C."
+    "qdlInstructions": "Встановіть перемичку на контакти JCTL, потім підключіть кабель USB-C.",
+    "qdlInstructionsButton": "Утримуйте кнопку EDL під час увімкнення, потім підключіть кабель USB."
   },
   "header": {
     "stepManufacturer": "Виробник",
     "stepBoard": "Плата",
     "stepOs": "ОС",
     "stepStorage": "Сховище",
+    "stepDevice": "Пристрій",
     "stepImage": "Образ",
     "resetTooltip": "Почати спочатку",
     "stepTooltip": "Змінити {{step}}"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -8,6 +8,8 @@
     "chooseBoard": "选择开发板",
     "chooseOs": "选择系统",
     "chooseStorage": "选择存储设备",
+    "device": "设备",
+    "chooseDevice": "选择设备",
     "welcomeHeading": "欢迎使用 Armbian Imager",
     "welcomeIntro": "选好开发板和镜像就行，剩下的下载、写入 SD 卡或 U 盘以及校验都交给我们。",
     "startNow": "立即开始",
@@ -97,13 +99,15 @@
     "hideSystemDevices": "隐藏系统磁盘",
     "locked": "已锁定",
     "qdlNotFound": "未找到 EDL 设备。请将开发板切换到 EDL 模式，并通过 USB 连接。",
-    "qdlInstructions": "在 JCTL 引脚上装好跳线帽，然后接入 USB-C 数据线。"
+    "qdlInstructions": "在 JCTL 引脚上装好跳线帽，然后接入 USB-C 数据线。",
+    "qdlInstructionsButton": "开机时按住 EDL 按钮，然后接入 USB 数据线。"
   },
   "header": {
     "stepManufacturer": "制造商",
     "stepBoard": "开发板",
     "stepOs": "系统",
     "stepStorage": "存储设备",
+    "stepDevice": "设备",
     "stepImage": "镜像",
     "resetTooltip": "重新开始",
     "stepTooltip": "更改{{step}}"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,8 @@ export interface ImageInfo {
   stability: string;
   /** Image format: "sd" (block), "qdl" (Qualcomm EDL), "rootfs", "qemu", "hyperv" */
   format: string;
+  /** Storage target ("ufs" = raw Firehose write to internal UFS via QDL), else null. */
+  storage?: string | null;
   /** Companion files (bootloaders, firmware, etc.) */
   companions: CompanionInfo[];
   /** Display variant files for multi-panel devices */
@@ -48,6 +50,33 @@ export interface ImageInfo {
   // Custom image fields
   is_custom?: boolean;
   custom_path?: string;
+}
+
+/** How an image is written: raw block (dd), QDL TAR (Firehose rawprogram), or QDL UFS (raw Firehose write). */
+export const FLASH_METHOD = {
+  BLOCK: 'block',
+  QDL: 'qdl',
+  QDL_UFS: 'qdl-ufs',
+} as const;
+
+export type FlashMethod = (typeof FLASH_METHOD)[keyof typeof FLASH_METHOD];
+
+/** Single source of truth for the write path of an image. UFS is detected by the
+ *  storage field (the API ships it as format "sd"), QDL TAR by the "qdl" format. */
+export function deriveFlashMethod(image: Pick<ImageInfo, 'format' | 'storage'>): FlashMethod {
+  if (image.storage?.toLowerCase() === 'ufs') return FLASH_METHOD.QDL_UFS;
+  if (image.format === 'qdl') return FLASH_METHOD.QDL;
+  return FLASH_METHOD.BLOCK;
+}
+
+/** A flash method targets a Qualcomm EDL device (QDL TAR or raw UFS) rather than a block device. */
+export function isEdlMethod(method: FlashMethod | null | undefined): boolean {
+  return !!method && method !== FLASH_METHOD.BLOCK;
+}
+
+/** Whether an image flashes over EDL; the EDL-aware counterpart of a plain block write. */
+export function isEdlImage(image: Pick<ImageInfo, 'format' | 'storage'>): boolean {
+  return isEdlMethod(deriveFlashMethod(image));
 }
 
 /** Companion file info (bootloader, fip, recovery, etc.) */


### PR DESCRIPTION
# Flash UFS images to Qualcomm boards over EDL

Lets the imager flash Armbian UFS images to Qualcomm boards in EDL mode, starting with the Radxa Dragon Q6A. These images were hidden until now, since the imager could only write block devices and QDL TAR archives, not raw UFS.

The catalog now shows `storage=ufs` images and the backend writes them with a single Firehose `program` at 4096-byte sectors. It pulls the firehose loader and the provisioning descriptor from `armbian/qcombin`. A blank module NAKs the first write, so the imager provisions it in the same Sahara session and retries. Autoconfig reads the GPT at 4096-byte sectors so first-boot profiles still land. One shared registry holds each board's loader family, descriptor and EDL-entry hint.

In the UI, the storage step detects the EDL device and labels the target "Device" with a USB icon instead of "Storage", since the board shows up as a USB download device rather than a disk. Existing QDL TAR boards (Arduino Uno Q) flash exactly as before; only the label changes. The descriptor is already live on `armbian/qcombin` `main`.

Closes #145
