### PR TITLE
fix(devices): hide internal/system disks from flash targets (#159)

### DIFF
--- a/src-tauri/src/devices/linux.rs
+++ b/src-tauri/src/devices/linux.rs
@@ -27,7 +27,7 @@ fn is_device_read_only(device_name: &str) -> bool {
 pub fn get_block_devices() -> Result<Vec<BlockDevice>, String> {
     // JSON output parses reliably even when model names contain spaces.
     let output = Command::new("lsblk")
-        .args(["-dpJo", "NAME,SIZE,MODEL,RM,TRAN", "-b"])
+        .args(["-dpJo", "NAME,SIZE,MODEL,RM,HOTPLUG,TRAN", "-b"])
         .output()
         .map_err(|e| {
             log_error!("devices", "Failed to run lsblk: {}", e);
@@ -74,8 +74,8 @@ pub fn get_block_devices() -> Result<Vec<BlockDevice>, String> {
 
         let dev_name = path.strip_prefix("/dev/").unwrap_or(path);
 
-        // Flag rather than drop system disks, matching the macOS behavior.
-        let is_system = system_disks
+        // The disk backing the running root/boot mounts is always treated as system.
+        let is_running_system = system_disks
             .iter()
             .any(|sys| sys.starts_with(dev_name) || dev_name.starts_with(sys));
 
@@ -99,6 +99,14 @@ pub fn get_block_devices() -> Result<Vec<BlockDevice>, String> {
             _ => false,
         };
 
+        // Fallback signal for the unknown-bus case below.
+        let is_hotplug = match &dev["hotplug"] {
+            serde_json::Value::Bool(b) => *b,
+            serde_json::Value::String(s) => s == "1",
+            serde_json::Value::Number(n) => n.as_u64() == Some(1),
+            _ => false,
+        };
+
         // Prefer the TRAN field, then infer the bus from the device path.
         let tran = dev["tran"].as_str().unwrap_or("");
         let bus_type = normalize_bus_type(tran).or_else(|| {
@@ -110,6 +118,13 @@ pub fn get_block_devices() -> Result<Vec<BlockDevice>, String> {
                 None
             }
         });
+
+        // Internal buses are system; USB/SD stay selectable; the running OS disk always wins.
+        let is_system = match bus_type.as_deref() {
+            Some("USB") | Some("SD") => false,
+            Some(_) => true,
+            None => !(is_removable || is_hotplug),
+        } || is_running_system;
 
         let is_read_only = is_device_read_only(dev_name);
 

--- a/src-tauri/src/devices/windows.rs
+++ b/src-tauri/src/devices/windows.rs
@@ -442,9 +442,13 @@ pub fn get_block_devices() -> Result<Vec<BlockDevice>, String> {
             let (model, is_removable, bus_type) = query_device_properties(disk_number)?;
             let drive_letters = get_drive_letters_for_disk(disk_number);
 
-            let is_system = drive_letters
+            let has_c_drive = drive_letters
                 .as_ref()
                 .map_or(false, |letters| letters.iter().any(|l| l == "C:"));
+
+            // Internal fixed disks are system; USB stays selectable; C: always wins.
+            let is_internal = !is_removable && bus_type.as_deref() != Some("USB");
+            let is_system = is_internal || has_c_drive;
 
             let name = match &drive_letters {
                 Some(letters) => format!("Disk {} ({})", disk_number, letters.join(", ")),

--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -7,7 +7,7 @@ import { ErrorDisplay, DeviceIcon, getDeviceBadge, BoardImage, MarqueeText } fro
 import type { BlockDevice, AutoconfigProfile, AutoconfigProfilesChangedDetail, FlashMethod } from '../../types';
 import { isEdlMethod } from '../../types';
 import { getBlockDevices, getQdlDevices, getQdlEdlEntry } from '../../hooks/useTauri';
-import { getAutoconfigProfiles } from '../../hooks/useSettings';
+import { getAutoconfigProfiles, getAllowSystemDevices } from '../../hooks/useSettings';
 import { useAsyncData } from '../../hooks/useAsyncData';
 import { useSkeletonLoading } from '../../hooks/useSkeletonLoading';
 import { POLLING, UI, EVENTS, qdlInstructionsKey } from '../../config';
@@ -52,6 +52,17 @@ export function DevicePanel({
 }: DevicePanelProps) {
   const { t } = useTranslation();
   const [showSystemDevices, setShowSystemDevices] = useState(false);
+  // Persistent opt-in to show and flash internal/system disks at the user's own risk.
+  const [allowSystemDevices, setAllowSystemDevices] = useState(false);
+
+  useEffect(() => {
+    const load = () => {
+      getAllowSystemDevices().then(setAllowSystemDevices).catch(() => {});
+    };
+    load();
+    window.addEventListener(EVENTS.SETTINGS_CHANGED, load);
+    return () => window.removeEventListener(EVENTS.SETTINGS_CHANGED, load);
+  }, []);
 
   const prevDevicesRef = useRef<BlockDevice[] | null>(null);
   const [devices, setDevices] = useState<BlockDevice[]>([]);
@@ -135,11 +146,12 @@ export function DevicePanel({
     return (devices && devices.length > 0) || !loading;
   }, [devices, loading]);
 
-  // Filter and sort devices based on the showSystemDevices toggle.
+  // System disks are shown when unlocked via settings, or peeked via the local toggle.
+  const showSystem = allowSystemDevices || showSystemDevices;
   const filteredDevices = useMemo(() => {
-    const filtered = showSystemDevices ? devices : devices.filter((d) => !d.is_system);
+    const filtered = showSystem ? devices : devices.filter((d) => !d.is_system);
     return sortDevices(filtered);
-  }, [devices, showSystemDevices]);
+  }, [devices, showSystem]);
 
   const { showSkeleton } = useSkeletonLoading(loading, devicesReady);
 
@@ -179,7 +191,7 @@ export function DevicePanel({
   }, [selectedDevice, pollDevices]);
 
   function handleDeviceClick(device: BlockDevice) {
-    if (device.is_system || device.is_read_only) return;
+    if (device.is_read_only || (device.is_system && !allowSystemDevices)) return;
     onSelect(device);
   }
 
@@ -230,6 +242,13 @@ export function DevicePanel({
                     </span>
                   </span>
                 </li>
+                {/* System/internal target: contextual danger row tied to the storage above. */}
+                {selectedDevice.is_system && (
+                  <li className="device-summary__syswarn">
+                    <TriangleAlert size={15} />
+                    <span>{t('flash.systemDeviceWarning')}</span>
+                  </li>
+                )}
                 {/* Opt-in autoconfig profile, integrated as the final summary row (Armbian images only). */}
                 {showAutoconfig && (
                   <li className="device-summary__profile">
@@ -311,7 +330,7 @@ export function DevicePanel({
           </span>
           <span className="device-alert__text">{t('flash.dataWarning')}</span>
 
-          {!isQdlMode && (
+          {!isQdlMode && !allowSystemDevices && (
             <button
               type="button"
               onClick={() => setShowSystemDevices(!showSystemDevices)}
@@ -362,7 +381,12 @@ export function DevicePanel({
                   const deviceType = getDeviceType(device);
                   const badge = getDeviceBadge(deviceType, t);
                   const colors = getDeviceColors(deviceType);
-                  const isDisabled = device.is_system || device.is_read_only;
+                  const isDisabled = device.is_read_only || (device.is_system && !allowSystemDevices);
+                  // Unlocked system disk: show its real drive glyph, not the lock (it is selectable).
+                  const iconType =
+                    device.is_system && allowSystemDevices
+                      ? getDeviceType({ ...device, is_system: false })
+                      : deviceType;
 
                   return (
                     <button
@@ -376,7 +400,7 @@ export function DevicePanel({
                         className="device-card__icon"
                         style={{ backgroundColor: colors.background, color: colors.text }}
                       >
-                        <DeviceIcon type={deviceType} size={22} />
+                        <DeviceIcon type={iconType} size={22} />
                       </span>
                       <span className="device-card__info">
                         <span className="device-card__name">

--- a/src/components/settings/PreferencesSection.tsx
+++ b/src/components/settings/PreferencesSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Lightbulb, Download, ShieldOff, Cpu, Sparkles, WifiOff } from 'lucide-react';
+import { Lightbulb, Download, ShieldOff, Cpu, Sparkles, WifiOff, ShieldAlert } from 'lucide-react';
 import {
   getShowMotd,
   setShowMotd,
@@ -12,6 +12,8 @@ import {
   setSkipVerify,
   getForceOffline,
   setForceOffline,
+  getAllowSystemDevices,
+  setAllowSystemDevices,
   getArmbianBoardDetection,
   setArmbianBoardDetection,
 } from '../../hooks/useSettings';
@@ -32,6 +34,7 @@ export function PreferencesSection() {
     showWelcome: boolean;
     skipVerify: boolean;
     forceOffline: boolean;
+    allowSystemDevices: boolean;
     armbianDetection: string;
     isArmbian: boolean;
   }>({
@@ -40,6 +43,7 @@ export function PreferencesSection() {
     showWelcome: getShowWelcome,
     skipVerify: getSkipVerify,
     forceOffline: getForceOffline,
+    allowSystemDevices: getAllowSystemDevices,
     armbianDetection: getArmbianBoardDetection,
     isArmbian: async () => {
       const info = await getSystemInfo();
@@ -57,6 +61,7 @@ export function PreferencesSection() {
   const [showWelcome, setShowWelcomeState] = useState<boolean>(true);
   const [skipVerify, setSkipVerifyState] = useState<boolean>(false);
   const [forceOffline, setForceOfflineState] = useState<boolean>(false);
+  const [allowSystemDevices, setAllowSystemDevicesState] = useState<boolean>(false);
   const [armbianDetection, setArmbianDetection] = useState<string>('disabled');
   const [isToggling, setIsToggling] = useState<boolean>(false);
   const [initialized, setInitialized] = useState(false);
@@ -69,6 +74,7 @@ export function PreferencesSection() {
     if (settingsGroup.showWelcome !== undefined) setShowWelcomeState(settingsGroup.showWelcome);
     if (settingsGroup.skipVerify !== undefined) setSkipVerifyState(settingsGroup.skipVerify);
     if (settingsGroup.forceOffline !== undefined) setForceOfflineState(settingsGroup.forceOffline);
+    if (settingsGroup.allowSystemDevices !== undefined) setAllowSystemDevicesState(settingsGroup.allowSystemDevices);
     if (settingsGroup.armbianDetection !== undefined) setArmbianDetection(settingsGroup.armbianDetection);
     setInitialized(true);
   }, [loaded, settingsGroup]);
@@ -154,6 +160,28 @@ export function PreferencesSection() {
       console.error('Failed to set force offline preference:', error);
       setForceOfflineState(previousValue);
       showError(t('settings.toast.forceOfflineError'));
+    } finally {
+      setIsToggling(false);
+    }
+  };
+
+  /** Toggles allow-system-devices optimistically, rolling back on failure; guarded by isToggling. */
+  const handleToggleAllowSystemDevices = async () => {
+    if (isToggling) return;
+
+    const previousValue = allowSystemDevices;
+    const newValue = !allowSystemDevices;
+    setAllowSystemDevicesState(newValue);
+    setIsToggling(true);
+
+    try {
+      await setAllowSystemDevices(newValue);
+      window.dispatchEvent(new Event(EVENTS.SETTINGS_CHANGED));
+      showSuccess(t('settings.toast.allowSystemDevicesUpdated'));
+    } catch (error) {
+      console.error('Failed to set allow system devices preference:', error);
+      setAllowSystemDevicesState(previousValue);
+      showError(t('settings.toast.allowSystemDevicesError'));
     } finally {
       setIsToggling(false);
     }
@@ -310,6 +338,34 @@ export function PreferencesSection() {
                 onChange={handleToggleForceOffline}
                 disabled={isToggling}
                 aria-label={t('settings.forceOffline')}
+              />
+              <span className="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      {/* Devices: unlock internal/system drives for flashing */}
+      <div className="settings-group">
+        <h4 className="settings-group__title">{t('settings.devices')}</h4>
+        <div className="settings-group__card">
+          <div className="settings-row">
+            <div className="settings-row__main">
+              <div className="settings-row__icon">
+                <ShieldAlert size={18} />
+              </div>
+              <div className="settings-row__text">
+                <div className="settings-row__label">{t('settings.allowSystemDevices')}</div>
+                <div className="settings-row__desc">{t('settings.allowSystemDevicesDescription')}</div>
+              </div>
+            </div>
+            <label className="toggle-switch">
+              <input
+                type="checkbox"
+                checked={allowSystemDevices}
+                onChange={handleToggleAllowSystemDevices}
+                disabled={isToggling}
+                aria-label={t('settings.allowSystemDevices')}
               />
               <span className="toggle-slider"></span>
             </label>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -69,6 +69,7 @@ export const SETTINGS = {
     CACHE_MAX_SIZE: 'cache_max_size',
     ARMBIAN_BOARD_DETECTION: 'armbian_board_detection',
     AUTOCONFIG_PROFILES: 'autoconfig_profiles',
+    ALLOW_SYSTEM_DEVICES: 'allow_system_devices',
   },
   DEFAULTS: {
     THEME: 'auto',
@@ -82,6 +83,7 @@ export const SETTINGS = {
     CACHE_ENABLED: true,
     ARMBIAN_BOARD_DETECTION: 'modal',
     AUTOCONFIG_PROFILES: [] as [],
+    ALLOW_SYSTEM_DEVICES: false,
   },
   ARMBIAN_DETECTION_MODES: {
     DISABLED: 'disabled',

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -181,6 +181,28 @@ export async function setForceOffline(value: boolean): Promise<void> {
   }
 }
 
+/** Get the allow-system-devices preference: show and allow flashing internal/system disks */
+export async function getAllowSystemDevices(): Promise<boolean> {
+  try {
+    const store = await getStore();
+    const value = await store.get<boolean>(SETTINGS.KEYS.ALLOW_SYSTEM_DEVICES);
+    return value ?? SETTINGS.DEFAULTS.ALLOW_SYSTEM_DEVICES;
+  } catch (error) {
+    throw new Error(`Failed to get allow system devices preference: ${error}`);
+  }
+}
+
+/** Set the allow-system-devices preference: show and allow flashing internal/system disks */
+export async function setAllowSystemDevices(value: boolean): Promise<void> {
+  try {
+    const store = await getStore();
+    await store.set(SETTINGS.KEYS.ALLOW_SYSTEM_DEVICES, value);
+    await store.save();
+  } catch (error) {
+    throw new Error(`Failed to set allow system devices preference: ${error}`);
+  }
+}
+
 // Cache settings: backend owns the canonical defaults; values here are fallbacks when it's unreachable.
 
 /** Get the cache enabled preference */

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -26,6 +26,7 @@
     "cachedImages": "Zwischengespeicherte Images"
   },
   "flash": {
+    "systemDeviceWarning": "Das Beschreiben kann das laufende Betriebssystem zerstören.",
     "downloading": "Image wird heruntergeladen...",
     "verifyingSha": "Download wird überprüft...",
     "decompressing": "Image wird entpackt...",
@@ -230,6 +231,9 @@
       "hoursAgo": "vor {{count}}h",
       "daysAgo": "vor {{count}}d"
     },
+    "devices": "Geräte",
+    "allowSystemDevices": "Systemlaufwerke zulassen",
+    "allowSystemDevicesDescription": "Riskant: das laufende Betriebssystem kann überschrieben werden.",
     "armbian": {
       "title": "Armbian",
       "label": "Board automatisch erkennen",
@@ -239,6 +243,8 @@
       "mode_auto": "Automatisch"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Einstellung für Systemlaufwerke aktualisiert",
+      "allowSystemDevicesError": "Einstellung für Systemlaufwerke konnte nicht aktualisiert werden",
       "motdUpdated": "Tipps-Einstellung aktualisiert",
       "motdError": "Tipps-Einstellung konnte nicht aktualisiert werden",
       "welcomeUpdated": "Einstellung für Willkommensbildschirm aktualisiert",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,6 +26,7 @@
     "cachedImages": "Cached Images"
   },
   "flash": {
+    "systemDeviceWarning": "Flashing this can destroy the running OS.",
     "downloading": "Downloading image...",
     "verifyingSha": "Verifying the download...",
     "decompressing": "Decompressing image...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}h ago",
       "daysAgo": "{{count}}d ago"
     },
+    "devices": "Devices",
+    "allowSystemDevices": "Allow system drives",
+    "allowSystemDevicesDescription": "Risky: you can overwrite the running OS.",
     "armbian": {
       "title": "Armbian",
       "label": "Auto-detect board",
@@ -239,6 +243,8 @@
       "mode_auto": "Silent"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "System drives setting updated",
+      "allowSystemDevicesError": "Failed to update system drives setting",
       "motdUpdated": "Tips setting updated",
       "motdError": "Failed to update tips setting",
       "welcomeUpdated": "Welcome screen setting updated",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -26,6 +26,7 @@
     "cachedImages": "Imágenes en caché"
   },
   "flash": {
+    "systemDeviceWarning": "Grabarla puede destruir el sistema operativo en uso.",
     "downloading": "Descargando imagen...",
     "verifyingSha": "Verificando integridad de la descarga...",
     "decompressing": "Descomprimiendo imagen...",
@@ -230,6 +231,9 @@
       "hoursAgo": "hace {{count}}h",
       "daysAgo": "hace {{count}}d"
     },
+    "devices": "Dispositivos",
+    "allowSystemDevices": "Permitir unidades del sistema",
+    "allowSystemDevicesDescription": "Arriesgado: puedes sobrescribir el sistema operativo en uso.",
     "armbian": {
       "title": "Armbian",
       "label": "Detectar placa automáticamente",
@@ -239,6 +243,8 @@
       "mode_auto": "Silencioso"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Ajuste de unidades del sistema actualizado",
+      "allowSystemDevicesError": "No se pudo actualizar el ajuste de unidades del sistema",
       "motdUpdated": "Configuración de consejos actualizada",
       "motdError": "Error al actualizar la configuración de consejos",
       "welcomeUpdated": "Configuración de pantalla de bienvenida actualizada",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -26,6 +26,7 @@
     "cachedImages": "Images en cache"
   },
   "flash": {
+    "systemDeviceWarning": "L'écrire peut détruire le système d'exploitation en cours.",
     "downloading": "Téléchargement de l'image...",
     "verifyingSha": "Vérification de l'intégrité du téléchargement...",
     "decompressing": "Décompression de l'image...",
@@ -230,6 +231,9 @@
       "hoursAgo": "il y a {{count}}h",
       "daysAgo": "il y a {{count}}j"
     },
+    "devices": "Périphériques",
+    "allowSystemDevices": "Autoriser les disques système",
+    "allowSystemDevicesDescription": "Risqué : peut écraser le système d'exploitation en cours d'exécution.",
     "armbian": {
       "title": "Armbian",
       "label": "Détecter la carte automatiquement",
@@ -239,6 +243,8 @@
       "mode_auto": "Silencieux"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Réglage des disques système mis à jour",
+      "allowSystemDevicesError": "Échec de la mise à jour du réglage des disques système",
       "motdUpdated": "Paramètre des conseils mis à jour",
       "motdError": "Échec de la mise à jour du paramètre des conseils",
       "welcomeUpdated": "Paramètre de l'écran d'accueil mis à jour",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -26,6 +26,7 @@
     "cachedImages": "Predmemorirane slike"
   },
   "flash": {
+    "systemDeviceWarning": "Zapisivanje može uništiti pokrenuti operativni sustav.",
     "downloading": "Preuzimanje slike...",
     "verifyingSha": "Provjera preuzimanja...",
     "decompressing": "Raspakiravanje slike...",
@@ -230,6 +231,9 @@
       "hoursAgo": "prije {{count}}h",
       "daysAgo": "prije {{count}}d"
     },
+    "devices": "Uređaji",
+    "allowSystemDevices": "Dopusti sistemske diskove",
+    "allowSystemDevicesDescription": "Rizično: možeš prebrisati pokrenuti operativni sustav.",
     "armbian": {
       "title": "Armbian",
       "label": "Automatsko otkrivanje ploče",
@@ -239,6 +243,8 @@
       "mode_auto": "Tiho"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Postavka sistemskih diskova ažurirana",
+      "allowSystemDevicesError": "Ažuriranje postavke sistemskih diskova nije uspjelo",
       "motdUpdated": "Postavka savjeta je ažurirana",
       "motdError": "Ažuriranje postavke savjeta nije uspjelo",
       "welcomeUpdated": "Postavka početnog zaslona je ažurirana",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -26,6 +26,7 @@
     "cachedImages": "Immagini in cache"
   },
   "flash": {
+    "systemDeviceWarning": "Scriverci può distruggere il sistema operativo in uso.",
     "downloading": "Download dell'immagine...",
     "verifyingSha": "Verifica del download...",
     "decompressing": "Decompressione dell'immagine...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}h fa",
       "daysAgo": "{{count}}g fa"
     },
+    "devices": "Dispositivi",
+    "allowSystemDevices": "Consenti dischi di sistema",
+    "allowSystemDevicesDescription": "Rischioso: puoi sovrascrivere il sistema operativo in uso.",
     "armbian": {
       "title": "Armbian",
       "label": "Rileva la scheda automaticamente",
@@ -239,6 +243,8 @@
       "mode_auto": "Silenzioso"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Impostazione dischi di sistema aggiornata",
+      "allowSystemDevicesError": "Impossibile aggiornare l'impostazione dischi di sistema",
       "motdUpdated": "Impostazione suggerimenti aggiornata",
       "motdError": "Impossibile aggiornare l'impostazione dei suggerimenti",
       "welcomeUpdated": "Impostazione schermata di benvenuto aggiornata",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -26,6 +26,7 @@
     "cachedImages": "キャッシュ済みイメージ"
   },
   "flash": {
+    "systemDeviceWarning": "書き込むと実行中のOSが破壊される可能性があります。",
     "downloading": "イメージをダウンロードしています...",
     "verifyingSha": "ダウンロードを検証しています...",
     "decompressing": "イメージを展開しています...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}時間前",
       "daysAgo": "{{count}}日前"
     },
+    "devices": "デバイス",
+    "allowSystemDevices": "システムドライブを許可",
+    "allowSystemDevicesDescription": "危険：実行中のOSを上書きする可能性があります。",
     "armbian": {
       "title": "Armbian",
       "label": "ボードを自動検出",
@@ -239,6 +243,8 @@
       "mode_auto": "サイレント"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "システムドライブ設定を更新しました",
+      "allowSystemDevicesError": "システムドライブ設定の更新に失敗しました",
       "motdUpdated": "ヒントの設定を更新しました",
       "motdError": "ヒントの設定の更新に失敗しました",
       "welcomeUpdated": "ようこそ画面の設定を更新しました",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -26,6 +26,7 @@
     "cachedImages": "캐시된 이미지"
   },
   "flash": {
+    "systemDeviceWarning": "기록하면 실행 중인 OS가 손상될 수 있습니다.",
     "downloading": "이미지 다운로드 중...",
     "verifyingSha": "다운로드 확인 중...",
     "decompressing": "이미지 압축 해제 중...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}시간 전",
       "daysAgo": "{{count}}일 전"
     },
+    "devices": "장치",
+    "allowSystemDevices": "시스템 드라이브 허용",
+    "allowSystemDevicesDescription": "위험: 실행 중인 OS를 덮어쓸 수 있습니다.",
     "armbian": {
       "title": "Armbian",
       "label": "보드 자동 감지",
@@ -239,6 +243,8 @@
       "mode_auto": "자동"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "시스템 드라이브 설정이 업데이트되었습니다",
+      "allowSystemDevicesError": "시스템 드라이브 설정을 업데이트하지 못했습니다",
       "motdUpdated": "팁 설정을 업데이트했습니다",
       "motdError": "팁 설정을 업데이트하지 못했습니다",
       "welcomeUpdated": "시작 화면 설정을 업데이트했습니다",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -26,6 +26,7 @@
     "cachedImages": "Gecachte images"
   },
   "flash": {
+    "systemDeviceWarning": "Schrijven kan het draaiende besturingssysteem vernietigen.",
     "downloading": "Image downloaden...",
     "verifyingSha": "Download controleren...",
     "decompressing": "Image uitpakken...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}u geleden",
       "daysAgo": "{{count}}d geleden"
     },
+    "devices": "Apparaten",
+    "allowSystemDevices": "Systeemschijven toestaan",
+    "allowSystemDevicesDescription": "Riskant: je kunt het draaiende besturingssysteem overschrijven.",
     "armbian": {
       "title": "Armbian",
       "label": "Board automatisch detecteren",
@@ -239,6 +243,8 @@
       "mode_auto": "Stil"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Instelling voor systeemschijven bijgewerkt",
+      "allowSystemDevicesError": "Bijwerken van instelling voor systeemschijven mislukt",
       "motdUpdated": "Tips-instelling bijgewerkt",
       "motdError": "Kan tips-instelling niet bijwerken",
       "welcomeUpdated": "Instelling welkomstscherm bijgewerkt",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -26,6 +26,7 @@
     "cachedImages": "Obrazy w pamięci podręcznej"
   },
   "flash": {
+    "systemDeviceWarning": "Zapis może zniszczyć uruchomiony system.",
     "downloading": "Pobieranie obrazu...",
     "verifyingSha": "Weryfikowanie pobranego pliku...",
     "decompressing": "Rozpakowywanie obrazu...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}h temu",
       "daysAgo": "{{count}}d temu"
     },
+    "devices": "Urządzenia",
+    "allowSystemDevices": "Zezwalaj na dyski systemowe",
+    "allowSystemDevicesDescription": "Ryzykowne: możesz nadpisać uruchomiony system.",
     "armbian": {
       "title": "Armbian",
       "label": "Automatyczne wykrywanie płytki",
@@ -239,6 +243,8 @@
       "mode_auto": "Ciche"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Zaktualizowano ustawienie dysków systemowych",
+      "allowSystemDevicesError": "Nie udało się zaktualizować ustawienia dysków systemowych",
       "motdUpdated": "Ustawienie porad zaktualizowane",
       "motdError": "Nie udało się zaktualizować ustawienia porad",
       "welcomeUpdated": "Ustawienie ekranu powitalnego zaktualizowane",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -26,6 +26,7 @@
     "cachedImages": "Imagens em cache"
   },
   "flash": {
+    "systemDeviceWarning": "Gravá-lo pode destruir o sistema operacional em execução.",
     "downloading": "Baixando imagem...",
     "verifyingSha": "Verificando o download...",
     "decompressing": "Descompactando imagem...",
@@ -230,6 +231,9 @@
       "hoursAgo": "há {{count}}h",
       "daysAgo": "há {{count}}d"
     },
+    "devices": "Dispositivos",
+    "allowSystemDevices": "Permitir discos do sistema",
+    "allowSystemDevicesDescription": "Arriscado: você pode sobrescrever o sistema operacional em execução.",
     "armbian": {
       "title": "Armbian",
       "label": "Detectar placa automaticamente",
@@ -239,6 +243,8 @@
       "mode_auto": "Silencioso"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Configuração de discos do sistema atualizada",
+      "allowSystemDevicesError": "Falha ao atualizar a configuração de discos do sistema",
       "motdUpdated": "Configuração de dicas atualizada",
       "motdError": "Falha ao atualizar configuração de dicas",
       "welcomeUpdated": "Configuração da tela de boas-vindas atualizada",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -26,6 +26,7 @@
     "cachedImages": "Imagens em cache"
   },
   "flash": {
+    "systemDeviceWarning": "Gravá-lo pode destruir o sistema operativo em execução.",
     "downloading": "A transferir imagem...",
     "verifyingSha": "A verificar a transferência...",
     "decompressing": "A descomprimir imagem...",
@@ -230,6 +231,9 @@
       "hoursAgo": "há {{count}}h",
       "daysAgo": "há {{count}}d"
     },
+    "devices": "Dispositivos",
+    "allowSystemDevices": "Permitir discos do sistema",
+    "allowSystemDevicesDescription": "Arriscado: pode substituir o sistema operativo em execução.",
     "armbian": {
       "title": "Armbian",
       "label": "Detetar placa automaticamente",
@@ -239,6 +243,8 @@
       "mode_auto": "Silencioso"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Definição de discos do sistema atualizada",
+      "allowSystemDevicesError": "Falha ao atualizar a definição de discos do sistema",
       "motdUpdated": "Definição de dicas atualizada",
       "motdError": "Falha ao atualizar a definição de dicas",
       "welcomeUpdated": "Definição do ecrã de boas-vindas atualizada",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -26,6 +26,7 @@
     "cachedImages": "Кэшированные образы"
   },
   "flash": {
+    "systemDeviceWarning": "Запись может уничтожить работающую ОС.",
     "downloading": "Загрузка образа...",
     "verifyingSha": "Проверка загрузки...",
     "decompressing": "Распаковка образа...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}ч назад",
       "daysAgo": "{{count}}д назад"
     },
+    "devices": "Устройства",
+    "allowSystemDevices": "Разрешить системные диски",
+    "allowSystemDevicesDescription": "Рискованно: можно перезаписать работающую ОС.",
     "armbian": {
       "title": "Armbian",
       "label": "Автоопределение платы",
@@ -239,6 +243,8 @@
       "mode_auto": "Тихий"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Настройка системных дисков обновлена",
+      "allowSystemDevicesError": "Не удалось обновить настройку системных дисков",
       "motdUpdated": "Настройка подсказок обновлена",
       "motdError": "Не удалось обновить настройку подсказок",
       "welcomeUpdated": "Настройка экрана приветствия обновлена",

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -26,6 +26,7 @@
     "cachedImages": "Predpomnjene slike"
   },
   "flash": {
+    "systemDeviceWarning": "Zapisovanje lahko uniči delujoči operacijski sistem.",
     "downloading": "Prenašanje slike...",
     "verifyingSha": "Preverjanje celovitosti prenosa...",
     "decompressing": "Razširjanje slike...",
@@ -230,6 +231,9 @@
       "hoursAgo": "pred {{count}}h",
       "daysAgo": "pred {{count}}d"
     },
+    "devices": "Naprave",
+    "allowSystemDevices": "Dovoli sistemske diske",
+    "allowSystemDevicesDescription": "Tvegano: lahko prepišeš delujoči operacijski sistem.",
     "armbian": {
       "title": "Armbian",
       "label": "Samodejna zaznava plošče",
@@ -239,6 +243,8 @@
       "mode_auto": "Samodejno"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Nastavitev sistemskih diskov posodobljena",
+      "allowSystemDevicesError": "Posodobitev nastavitve sistemskih diskov ni uspela",
       "motdUpdated": "Nastavitev nasvetov posodobljena",
       "motdError": "Nastavitve nasvetov ni bilo mogoče posodobiti",
       "welcomeUpdated": "Nastavitev pozdravnega zaslona posodobljena",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -26,6 +26,7 @@
     "cachedImages": "Cachade avbildningar"
   },
   "flash": {
+    "systemDeviceWarning": "Att skriva till den kan förstöra operativsystemet som körs.",
     "downloading": "Laddar ner avbildning...",
     "verifyingSha": "Verifierar nedladdningen...",
     "decompressing": "Packar upp avbildning...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}} tim sedan",
       "daysAgo": "{{count}} dgr sedan"
     },
+    "devices": "Enheter",
+    "allowSystemDevices": "Tillåt systemdiskar",
+    "allowSystemDevicesDescription": "Riskabelt: du kan skriva över operativsystemet som körs.",
     "armbian": {
       "title": "Armbian",
       "label": "Identifiera kort automatiskt",
@@ -239,6 +243,8 @@
       "mode_auto": "Tyst"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Inställning för systemdiskar uppdaterad",
+      "allowSystemDevicesError": "Det gick inte att uppdatera inställningen för systemdiskar",
       "motdUpdated": "Tipsinställning uppdaterad",
       "motdError": "Det gick inte att uppdatera tipsinställningen",
       "welcomeUpdated": "Inställning för välkomstskärm uppdaterad",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -26,6 +26,7 @@
     "cachedImages": "Önbellekteki imajlar"
   },
   "flash": {
+    "systemDeviceWarning": "Yazmak çalışan işletim sistemini yok edebilir.",
     "downloading": "İmaj indiriliyor...",
     "verifyingSha": "İndirme bütünlüğü doğrulanıyor...",
     "decompressing": "İmaj açılıyor...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}sa önce",
       "daysAgo": "{{count}}g önce"
     },
+    "devices": "Aygıtlar",
+    "allowSystemDevices": "Sistem sürücülerine izin ver",
+    "allowSystemDevicesDescription": "Riskli: çalışan işletim sistemini üzerine yazabilirsiniz.",
     "armbian": {
       "title": "Armbian",
       "label": "Kartı otomatik algıla",
@@ -239,6 +243,8 @@
       "mode_auto": "Sessiz"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Sistem sürücüleri ayarı güncellendi",
+      "allowSystemDevicesError": "Sistem sürücüleri ayarı güncellenemedi",
       "motdUpdated": "İpucu ayarı güncellendi",
       "motdError": "İpucu ayarı güncellenemedi",
       "welcomeUpdated": "Karşılama ekranı ayarı güncellendi",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -26,6 +26,7 @@
     "cachedImages": "Кешовані образи"
   },
   "flash": {
+    "systemDeviceWarning": "Запис може знищити запущену ОС.",
     "downloading": "Завантаження образу...",
     "verifyingSha": "Перевірка цілісності завантаження...",
     "decompressing": "Розпакування образу...",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}}год тому",
       "daysAgo": "{{count}}д тому"
     },
+    "devices": "Пристрої",
+    "allowSystemDevices": "Дозволити системні диски",
+    "allowSystemDevicesDescription": "Ризиковано: можна перезаписати запущену ОС.",
     "armbian": {
       "title": "Armbian",
       "label": "Автовизначення плати",
@@ -239,6 +243,8 @@
       "mode_auto": "Автоматичний"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "Налаштування системних дисків оновлено",
+      "allowSystemDevicesError": "Не вдалося оновити налаштування системних дисків",
       "motdUpdated": "Налаштування підказок оновлено",
       "motdError": "Не вдалося оновити налаштування підказок",
       "welcomeUpdated": "Налаштування вітального екрана оновлено",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -26,6 +26,7 @@
     "cachedImages": "缓存镜像"
   },
   "flash": {
+    "systemDeviceWarning": "写入可能会破坏正在运行的操作系统。",
     "downloading": "正在下载镜像……",
     "verifyingSha": "正在校验下载内容……",
     "decompressing": "正在解压镜像……",
@@ -230,6 +231,9 @@
       "hoursAgo": "{{count}} 小时前",
       "daysAgo": "{{count}} 天前"
     },
+    "devices": "设备",
+    "allowSystemDevices": "允许系统磁盘",
+    "allowSystemDevicesDescription": "有风险：可能覆盖正在运行的操作系统。",
     "armbian": {
       "title": "Armbian",
       "label": "自动检测开发板",
@@ -239,6 +243,8 @@
       "mode_auto": "静默"
     },
     "toast": {
+      "allowSystemDevicesUpdated": "系统磁盘设置已更新",
+      "allowSystemDevicesError": "更新系统磁盘设置失败",
       "motdUpdated": "提示设置已更新",
       "motdError": "更新提示设置失败",
       "welcomeUpdated": "欢迎界面设置已更新",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1767,6 +1767,24 @@
   color: var(--color-error);
 }
 
+.device-summary__syswarn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 11px 16px;
+  border-top: 1px solid rgba(var(--color-error-rgb), 0.24);
+  background: rgba(var(--color-error-rgb), 0.08);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-error);
+}
+
+.device-summary__syswarn svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
 .device-confirm__actions {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
Closes #159.

A user with two NVMe drives saw the second one (internal, mounted at /home) offered as a writable target, because only the disk holding /, /boot or /boot/efi was flagged as system.

Detection now keys off the bus type: internal buses (NVMe/SATA/SAS) are hidden by default, SD and USB stay selectable, and the root/boot check still covers boards that boot from the disk being reflashed. Same logic on Windows; macOS already did this. Bus type beats balena's RM/HOTPLUG rule because a hot-plug PCIe NVMe can report HOTPLUG=1.

A new opt-in setting (off by default) unlocks internal/system disks at your own risk, with the real drive icon instead of a lock and a warning row in the confirm screen. Translated across all 18 locales.