### PR TITLE
feat(qdl): serve the board registry from the API

### DIFF
--- a/src-tauri/src/commands/qdl_operations.rs
+++ b/src-tauri/src/commands/qdl_operations.rs
@@ -93,15 +93,27 @@ pub async fn flash_qdl_ufs_image(
     let flash_state = state.flash_state.clone();
     flash_state.reset();
 
-    let loader_path = qdl::loader::ensure_loader(&soc, &board_slug)
-        .await
-        .map_err(|e| {
-            log_error!("qdl_operations", "Firehose loader unavailable: {}", e);
-            e
-        })?;
+    // Resolve the board's QDL facts from the API (bundled fallback), then fetch the
+    // loader and provisioning descriptor from the API blob proxy with digest checks.
+    let resolved = qdl::registry::resolve(&board_slug).await.ok_or_else(|| {
+        let msg = format!("No QDL metadata for board '{board_slug}' (SoC hint '{soc}')");
+        log_error!("qdl_operations", "{}", msg);
+        format!("[QDL_ERROR] {msg}")
+    })?;
+
+    if resolved.storage != qdl::QdlStorage::Ufs {
+        return Err(format!(
+            "[QDL_ERROR] Board '{board_slug}' is not a UFS QDL target"
+        ));
+    }
+
+    let loader_path = qdl::loader::ensure_loader(&resolved).await.map_err(|e| {
+        log_error!("qdl_operations", "Firehose loader unavailable: {}", e);
+        e
+    })?;
 
     // Provisioning descriptor for setting up a brand-new (unprovisioned) module.
-    let provision = qdl::provision::ensure_provision_xml(&soc, &board_slug).await;
+    let provision = qdl::provision::ensure_provision_xml(&resolved).await;
     if let qdl::provision::ProvisionSource::Unavailable(reason) = &provision {
         log_warn!("qdl_operations", "Provision XML unavailable: {}", reason);
     }
@@ -135,10 +147,4 @@ pub async fn flash_qdl_ufs_image(
         Err(e) => log_error!("qdl_operations", "QDL UFS flash failed: {}", e),
     }
     result
-}
-
-/// EDL-entry method ("button" or "jumper") for a board's on-screen hint, or null if unknown.
-#[tauri::command]
-pub async fn get_qdl_edl_entry(board_slug: String) -> Option<String> {
-    qdl::boards::find(&board_slug).map(|b| b.edl_entry.as_str().to_string())
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -199,7 +199,7 @@ fn open_url_windows(url: &str) -> Result<(), String> {
 #[tauri::command]
 pub async fn check_connectivity() -> bool {
     match CONNECTIVITY_CLIENT
-        .get(crate::config::urls::HEALTH)
+        .get(crate::config::urls::health())
         .send()
         .await
     {

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -14,11 +14,18 @@ pub mod app {
 
 /// API endpoints and URLs
 pub mod urls {
-    /// Armbian REST API base URL
-    pub const API_BASE: &str = "https://api.armbian.com/api/v1";
+    const API_BASE_DEFAULT: &str = "https://api.armbian.com/api/v1";
+
+    /// Armbian REST API base. Overridable at runtime via `ARMBIAN_API_BASE` so a
+    /// dev/test build can be pointed at a local API without a rebuild.
+    pub fn api_base() -> String {
+        std::env::var("ARMBIAN_API_BASE").unwrap_or_else(|_| API_BASE_DEFAULT.to_string())
+    }
 
     /// Health check endpoint (no auth required)
-    pub const HEALTH: &str = "https://api.armbian.com/api/v1/health";
+    pub fn health() -> String {
+        format!("{}/health", api_base())
+    }
 
     /// Base URL for board images (api.armbian.com/api/v1/images/boards/{size}/{slug}.png)
     pub const BOARD_IMAGES_BASE: &str = "https://api.armbian.com/api/v1/images/boards/";
@@ -29,8 +36,11 @@ pub mod urls {
     /// Base URL for vendor logos (api.armbian.com/api/v1/images/vendors/{size}/{slug}.png)
     pub const VENDOR_IMAGES_BASE: &str = "https://api.armbian.com/api/v1/images/vendors/480/";
 
-    /// Base URL for QDL firehose loaders, by SoC family ({base}{family}/prog_firehose_ddr.elf).
-    pub const QCOMBIN_LOADER_BASE: &str = "https://raw.githubusercontent.com/armbian/qcombin/main/";
+    /// Base URL for QDL firehose loaders / provisioning XML, served by the API blob
+    /// proxy ({base}{family}/{path}). Follows `api_base` so it routes locally in dev.
+    pub fn qdl_blob_base() -> String {
+        format!("{}/qdl/blob/", api_base())
+    }
 }
 
 /// Download and decompression settings

--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -2,8 +2,10 @@
 //! pre-processed data, so no extraction or deduplication is needed.
 
 use super::models::{
-    ApiBoardSummary, ApiImage, BoardInfo, CompanionInfo, DisplayVariantInfo, ImageInfo,
+    ApiBoardSummary, ApiImage, BoardInfo, BoardQdlInfo, CompanionInfo, DisplayVariantInfo,
+    ImageInfo,
 };
+use crate::qdl::qdl_storage_supported;
 
 /// Map an API board summary to a frontend-facing BoardInfo
 pub fn map_board(api: &ApiBoardSummary) -> BoardInfo {
@@ -19,6 +21,10 @@ pub fn map_board(api: &ApiBoardSummary) -> BoardInfo {
         soc: api.soc.clone(),
         architecture: api.architecture.clone(),
         summary: api.summary.clone(),
+        qdl: api.qdl.as_ref().map(|q| BoardQdlInfo {
+            supported: qdl_storage_supported(&q.storage),
+            edl_entry: q.edl_entry.clone(),
+        }),
     }
 }
 

--- a/src-tauri/src/images/mod.rs
+++ b/src-tauri/src/images/mod.rs
@@ -5,7 +5,7 @@ mod filters;
 mod models;
 
 pub use filters::{map_board, map_images};
-pub use models::{ApiBoardSummary, ApiImage, ApiVendor, BoardInfo, ImageInfo};
+pub use models::{ApiBoardSummary, ApiImage, ApiQdl, ApiVendor, BoardInfo, ImageInfo};
 
 use models::ApiResponse;
 
@@ -99,6 +99,22 @@ async fn load_cache(name: &str) -> Result<String, String> {
     Ok(data)
 }
 
+/// Fetch a single board's QDL block from the API detail endpoint. Returns None
+/// when the board has no QDL metadata or on any network/parse error, so the
+/// caller falls back to the bundled registry.
+pub async fn fetch_board_qdl(slug: &str) -> Option<ApiQdl> {
+    let url = format!("{}/boards/{}", config::urls::api_base(), slug);
+    let response = API_CLIENT
+        .get(&url)
+        .send()
+        .await
+        .ok()?
+        .error_for_status()
+        .ok()?;
+    let parsed: models::ApiResponse<ApiBoardSummary> = response.json().await.ok()?;
+    parsed.data.qdl
+}
+
 /// Delete the pre-migration API cache file.
 pub fn cleanup_legacy_cache() {
     let legacy_path = assets_dir().join("api-images.json");
@@ -120,7 +136,7 @@ pub async fn fetch_boards() -> Result<Vec<ApiBoardSummary>, String> {
     log_debug!(
         "images",
         "Fetching boards from {}/boards",
-        config::urls::API_BASE
+        config::urls::api_base()
     );
 
     match fetch_boards_from_api().await {
@@ -144,7 +160,7 @@ pub async fn fetch_boards() -> Result<Vec<ApiBoardSummary>, String> {
 /// Fetch boards from the remote API, paginating until an empty page or the
 /// `MAX_PAGES` cap (both guard against a bad `meta.total` looping forever).
 async fn fetch_boards_from_api() -> Result<Vec<ApiBoardSummary>, String> {
-    let url_base = format!("{}/boards", config::urls::API_BASE);
+    let url_base = format!("{}/boards", config::urls::api_base());
     let mut all_boards = Vec::new();
     let mut page: u32 = 1;
     let limit: u32 = 500;
@@ -258,7 +274,7 @@ async fn fetch_images_from_api(
     branch: Option<&str>,
     promoted: Option<bool>,
 ) -> Result<Vec<ApiImage>, String> {
-    let url = format!("{}/boards/{}/images", config::urls::API_BASE, slug);
+    let url = format!("{}/boards/{}/images", config::urls::api_base(), slug);
 
     let mut params: Vec<(&str, String)> = Vec::new();
     if let Some(v) = variant {
@@ -301,7 +317,7 @@ pub async fn fetch_vendors() -> Result<Vec<ApiVendor>, String> {
     log_debug!(
         "images",
         "Fetching vendors from {}/vendors",
-        config::urls::API_BASE
+        config::urls::api_base()
     );
 
     match fetch_vendors_from_api().await {
@@ -324,7 +340,7 @@ pub async fn fetch_vendors() -> Result<Vec<ApiVendor>, String> {
 
 /// Fetch vendors directly from the remote API
 async fn fetch_vendors_from_api() -> Result<Vec<ApiVendor>, String> {
-    let url = format!("{}/vendors", config::urls::API_BASE);
+    let url = format!("{}/vendors", config::urls::api_base());
 
     let response: ApiResponse<Vec<ApiVendor>> = API_CLIENT
         .get(&url)

--- a/src-tauri/src/images/models.rs
+++ b/src-tauri/src/images/models.rs
@@ -39,6 +39,22 @@ pub struct ApiBoardSummary {
     pub soc: Option<String>,
     pub architecture: Option<String>,
     pub summary: Option<String>,
+    #[serde(default)]
+    pub qdl: Option<ApiQdl>,
+}
+
+/// QDL/EDL flashing metadata served on a board. Absent for non-QDL boards. The
+/// `*_sha256` digests are computed by the API over the cached loader/provision
+/// blobs so the imager can verify them after download.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiQdl {
+    pub family: String,
+    pub storage: String,
+    pub loader_rel: Option<String>,
+    pub provision_rel: Option<String>,
+    pub edl_entry: String,
+    pub loader_sha256: Option<String>,
+    pub provision_sha256: Option<String>,
 }
 
 // ─── API types: Images ───────────────────────────────────────────────────────
@@ -133,6 +149,18 @@ pub struct BoardInfo {
     pub architecture: Option<String>,
     /// Short board description
     pub summary: Option<String>,
+    /// Slim QDL/EDL support info for the UI gate; absent for non-QDL boards.
+    pub qdl: Option<BoardQdlInfo>,
+}
+
+/// QDL facts exposed to the frontend. Loader/provision blobs and digests stay
+/// backend-side; the UI only needs to know whether this build can flash the board.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardQdlInfo {
+    /// True when this build has a write path for the board's QDL `storage`.
+    pub supported: bool,
+    /// EDL entry hint ("button"/"jumper") for the on-screen instructions.
+    pub edl_entry: String,
 }
 
 /// Processed image information for the UI

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
         std::env::consts::ARCH
     );
     log_info!("main", "Config URLs:");
-    log_info!("main", "  - API Base: {}", config::urls::API_BASE);
+    log_info!("main", "  - API Base: {}", config::urls::api_base());
     log_info!(
         "main",
         "  - Board images: {}",
@@ -163,7 +163,6 @@ fn main() {
             commands::qdl_operations::get_qdl_devices,
             commands::qdl_operations::flash_qdl_image,
             commands::qdl_operations::flash_qdl_ufs_image,
-            commands::qdl_operations::get_qdl_edl_entry,
             commands::custom_image::select_custom_image,
             commands::custom_image::check_needs_decompression,
             commands::custom_image::decompress_custom_image,

--- a/src-tauri/src/qdl/boards.rs
+++ b/src-tauri/src/qdl/boards.rs
@@ -1,41 +1,29 @@
-//! Single source of truth for per-board QDL/EDL facts (loader family, UFS provisioning, EDL hint).
+//! Bundled fallback registry of per-board QDL/EDL facts, used when the Armbian API
+//! carries no `qdl` block for a board (offline, older API). The API is the primary source.
 
-#[derive(Clone, Copy)]
-pub enum EdlEntry {
-    Button,
-    Jumper,
-}
-
-impl EdlEntry {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            EdlEntry::Button => "button",
-            EdlEntry::Jumper => "jumper",
-        }
-    }
-}
+use crate::qdl::QdlStorage;
 
 pub struct QdlBoard {
     /// Matched case-insensitively as a substring of the board slug.
     pub slug_token: &'static str,
-    /// Used to resolve the loader family when the Armbian API leaves `soc` null.
+    /// Resolves the loader family via the SoC→family map.
     pub soc: &'static str,
+    pub storage: QdlStorage,
     pub provision_rel: Option<&'static str>,
-    pub edl_entry: EdlEntry,
 }
 
 pub const QDL_BOARDS: &[QdlBoard] = &[
     QdlBoard {
         slug_token: "dragon-q6a",
         soc: "QCS6490",
+        storage: QdlStorage::Ufs,
         provision_rel: Some("radxa-dragon-q6a/provision_ufs31_lun0_only.xml"),
-        edl_entry: EdlEntry::Button,
     },
     QdlBoard {
         slug_token: "arduino-uno-q",
         soc: "QRB2210",
+        storage: QdlStorage::Emmc,
         provision_rel: None,
-        edl_entry: EdlEntry::Jumper,
     },
 ];
 
@@ -52,7 +40,6 @@ mod tests {
     fn finds_board_by_slug_substring() {
         let b = find("radxa-dragon-q6a").expect("dragon-q6a is registered");
         assert_eq!(b.soc, "QCS6490");
-        assert_eq!(b.edl_entry.as_str(), "button");
         assert!(b.provision_rel.is_some());
         assert!(find("orangepi-5").is_none());
     }

--- a/src-tauri/src/qdl/loader.rs
+++ b/src-tauri/src/qdl/loader.rs
@@ -1,11 +1,12 @@
 //! Fetches and caches the Qualcomm firehose loader (`prog_firehose_ddr.elf`) for a
 //! board's SoC family from the armbian/qcombin repo, used to flash QDL/EDL devices.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::config;
 use crate::log_info;
 use crate::qdl::extract::FIREHOSE_ELF;
+use crate::qdl::registry::ResolvedQdl;
 use crate::utils::{fetch_to_file, loaders_dir};
 
 const MIN_LOADER_SIZE: u64 = 64 * 1024;
@@ -32,35 +33,37 @@ pub fn family_for_soc(soc: &str) -> Option<&'static str> {
         .map(|(_, family)| *family)
 }
 
-pub fn resolve_family(soc: &str, board_slug: &str) -> Option<&'static str> {
-    family_for_soc(soc)
-        .or_else(|| super::boards::find(board_slug).and_then(|b| family_for_soc(b.soc)))
-}
+/// Ensure the board's firehose loader is cached locally, downloading it from the
+/// API blob proxy on a miss and verifying the API-supplied SHA-256.
+pub async fn ensure_loader(resolved: &ResolvedQdl) -> Result<PathBuf, String> {
+    let loader_name = resolved.loader_rel.as_deref().unwrap_or(FIREHOSE_ELF);
+    let path = loaders_dir().join(&resolved.family).join(loader_name);
+    let expected = resolved.loader_sha256.clone();
 
-/// Ensure the board's firehose loader is cached locally, downloading from qcombin on a miss.
-pub async fn ensure_loader(soc: &str, board_slug: &str) -> Result<PathBuf, String> {
-    let family = resolve_family(soc, board_slug).ok_or_else(|| {
-        format!("No QDL firehose loader known for SoC '{soc}' / board '{board_slug}'")
-    })?;
-
-    let path = loaders_dir().join(family).join(FIREHOSE_ELF);
-    if path.exists() && validate_loader(&path).is_ok() {
-        log_info!(
-            "qdl::loader",
-            "Using cached firehose loader: {}",
-            path.display()
-        );
-        return Ok(path);
+    // Cache hit only if the on-disk copy still matches the API's current digest, so an
+    // updated loader on the server re-downloads instead of serving a stale file.
+    if let Ok(bytes) = std::fs::read(&path) {
+        if validate_loader_bytes(&bytes, expected.as_deref()).is_ok() {
+            log_info!(
+                "qdl::loader",
+                "Using cached firehose loader: {}",
+                path.display()
+            );
+            return Ok(path);
+        }
     }
 
     let url = format!(
         "{}{}/{}",
-        config::urls::QCOMBIN_LOADER_BASE,
-        family,
-        FIREHOSE_ELF
+        config::urls::qdl_blob_base(),
+        resolved.family,
+        loader_name
     );
     log_info!("qdl::loader", "Downloading firehose loader: {}", url);
-    fetch_to_file(&url, &path, validate_loader_bytes).await?;
+    fetch_to_file(&url, &path, move |bytes| {
+        validate_loader_bytes(bytes, expected.as_deref())
+    })
+    .await?;
     log_info!(
         "qdl::loader",
         "Cached firehose loader at {}",
@@ -69,25 +72,8 @@ pub async fn ensure_loader(soc: &str, board_slug: &str) -> Result<PathBuf, Strin
     Ok(path)
 }
 
-/// Validate an on-disk loader: ELF magic + a plausible minimum size.
-fn validate_loader(path: &Path) -> Result<(), String> {
-    use std::io::Read;
-    let len = std::fs::metadata(path).map_err(|e| e.to_string())?.len();
-    if len < MIN_LOADER_SIZE {
-        return Err(format!("loader too small ({len} bytes)"));
-    }
-    let mut head = [0u8; 4];
-    std::fs::File::open(path)
-        .and_then(|mut f| f.read_exact(&mut head))
-        .map_err(|e| e.to_string())?;
-    if &head != ELF_MAGIC {
-        return Err("not an ELF file".into());
-    }
-    Ok(())
-}
-
-/// Validate freshly downloaded loader bytes before installing them.
-fn validate_loader_bytes(bytes: &[u8]) -> Result<(), String> {
+/// Validate loader bytes: ELF magic + a plausible minimum size + optional digest.
+fn validate_loader_bytes(bytes: &[u8], expected_sha: Option<&str>) -> Result<(), String> {
     if (bytes.len() as u64) < MIN_LOADER_SIZE {
         return Err(format!(
             "downloaded loader too small ({} bytes)",
@@ -97,7 +83,7 @@ fn validate_loader_bytes(bytes: &[u8]) -> Result<(), String> {
     if !bytes.starts_with(ELF_MAGIC) {
         return Err("downloaded loader is not an ELF file".into());
     }
-    Ok(())
+    crate::qdl::registry::verify_digest(bytes, expected_sha)
 }
 
 #[cfg(test)]
@@ -112,12 +98,5 @@ mod tests {
         assert_eq!(family_for_soc("QRB2210"), Some("Agatti"));
         assert_eq!(family_for_soc("rk3588"), None);
         assert_eq!(family_for_soc(""), None);
-    }
-
-    #[test]
-    fn resolves_family_from_board_slug_when_soc_missing() {
-        assert_eq!(resolve_family("", "radxa-dragon-q6a"), Some("Kodiak"));
-        assert_eq!(resolve_family("QCS6490", ""), Some("Kodiak"));
-        assert_eq!(resolve_family("", "orangepi-5"), None);
     }
 }

--- a/src-tauri/src/qdl/mod.rs
+++ b/src-tauri/src/qdl/mod.rs
@@ -7,6 +7,7 @@ pub mod extract;
 pub mod flash;
 pub mod loader;
 pub mod provision;
+pub mod registry;
 
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,16 @@ pub enum QdlStorage {
 }
 
 impl QdlStorage {
+    /// Parse the API/bundle `storage` string into a backend we can write. Unknown
+    /// values yield `None`.
+    pub fn from_storage_str(s: &str) -> Option<Self> {
+        match s {
+            "ufs" => Some(QdlStorage::Ufs),
+            "emmc" => Some(QdlStorage::Emmc),
+            _ => None,
+        }
+    }
+
     pub fn sector_size(self) -> usize {
         match self {
             QdlStorage::Emmc => SECTOR_SIZE_EMMC,
@@ -40,6 +51,15 @@ impl QdlStorage {
             QdlStorage::Ufs => qdl::types::FirehoseStorageType::Ufs,
         }
     }
+}
+
+/// True when this build has a working QDL write path for the given `storage`.
+/// The flash pipeline is generic (Sahara + Firehose, blobs fetched from the API),
+/// so the only thing that gates a board is its storage backend: each needs a
+/// sector size and write path we implement explicitly. An unmapped value has no
+/// write path, so unknown => unsupported.
+pub fn qdl_storage_supported(storage: &str) -> bool {
+    QdlStorage::from_storage_str(storage).is_some()
 }
 
 /// Represents a Qualcomm device in EDL mode detected via USB

--- a/src-tauri/src/qdl/provision.rs
+++ b/src-tauri/src/qdl/provision.rs
@@ -7,12 +7,8 @@ use xmltree::{Element, XMLNode};
 
 use crate::config;
 use crate::log_info;
-use crate::qdl::loader::resolve_family;
+use crate::qdl::registry::ResolvedQdl;
 use crate::utils::{fetch_to_file, loaders_dir};
-
-fn provision_rel_path(board_slug: &str) -> Option<&'static str> {
-    crate::qdl::boards::find(board_slug).and_then(|b| b.provision_rel)
-}
 
 /// Where a board's UFS provisioning descriptor stands: ready, not declared, or expected but unreachable.
 pub enum ProvisionSource {
@@ -24,40 +20,49 @@ pub enum ProvisionSource {
 }
 
 /// Locate the board's UFS provisioning XML, downloading it to the cache on first use.
-pub async fn ensure_provision_xml(soc: &str, board_slug: &str) -> ProvisionSource {
-    let (Some(family), Some(rel)) = (
-        resolve_family(soc, board_slug),
-        provision_rel_path(board_slug),
-    ) else {
+pub async fn ensure_provision_xml(resolved: &ResolvedQdl) -> ProvisionSource {
+    let Some(rel) = resolved.provision_rel.as_deref() else {
         return ProvisionSource::Absent;
     };
-    match fetch_provision_xml(family, rel).await {
+    match fetch_provision_xml(&resolved.family, rel, resolved.provision_sha256.as_deref()).await {
         Ok(path) => ProvisionSource::Ready(path),
         Err(e) => ProvisionSource::Unavailable(e),
     }
 }
 
-async fn fetch_provision_xml(family: &str, rel: &str) -> Result<PathBuf, String> {
+async fn fetch_provision_xml(
+    family: &str,
+    rel: &str,
+    expected_sha: Option<&str>,
+) -> Result<PathBuf, String> {
     let path = loaders_dir().join(family).join(rel);
-    if path.exists() {
-        log_info!(
-            "qdl::provision",
-            "Using cached provision XML: {}",
-            path.display()
-        );
-        return Ok(path);
+    // Cache hit only if the on-disk copy still matches the API's current digest, so an
+    // updated descriptor on the server re-downloads instead of serving a stale file.
+    if let Ok(bytes) = std::fs::read(&path) {
+        if validate_provision_bytes(&bytes, expected_sha).is_ok() {
+            log_info!(
+                "qdl::provision",
+                "Using cached provision XML: {}",
+                path.display()
+            );
+            return Ok(path);
+        }
     }
-    let url = format!("{}{}/{}", config::urls::QCOMBIN_LOADER_BASE, family, rel);
+    let url = format!("{}{}/{}", config::urls::qdl_blob_base(), family, rel);
     log_info!("qdl::provision", "Downloading provision XML: {}", url);
-    fetch_to_file(&url, &path, validate_provision_bytes).await?;
+    let expected = expected_sha.map(str::to_string);
+    fetch_to_file(&url, &path, move |bytes| {
+        validate_provision_bytes(bytes, expected.as_deref())
+    })
+    .await?;
     Ok(path)
 }
 
-fn validate_provision_bytes(bytes: &[u8]) -> Result<(), String> {
+fn validate_provision_bytes(bytes: &[u8], expected_sha: Option<&str>) -> Result<(), String> {
     if !bytes.windows(5).any(|w| w == b"<ufs ") {
         return Err("Downloaded provision XML has no <ufs> commands".to_string());
     }
-    Ok(())
+    crate::qdl::registry::verify_digest(bytes, expected_sha)
 }
 
 /// Parse the `<ufs>` elements (in document order) into per-command attribute lists.
@@ -79,18 +84,4 @@ pub fn parse_ufs_commands(path: &std::path::Path) -> Result<Vec<Vec<(String, Str
         return Err("Provision XML contains no <ufs> commands".to_string());
     }
     Ok(commands)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolves_provision_path_by_slug() {
-        assert_eq!(
-            provision_rel_path("radxa-dragon-q6a"),
-            Some("radxa-dragon-q6a/provision_ufs31_lun0_only.xml")
-        );
-        assert_eq!(provision_rel_path("orangepi-5"), None);
-    }
 }

--- a/src-tauri/src/qdl/registry.rs
+++ b/src-tauri/src/qdl/registry.rs
@@ -1,0 +1,111 @@
+//! Resolves a board's QDL facts from the Armbian API (the served `qdl` block),
+//! falling back to the bundled default registry when the API has no metadata
+//! (offline, older API). The API is authoritative; the bundle keeps known
+//! boards flashable without a network round-trip.
+
+use crate::images::{self, ApiQdl};
+use crate::qdl::boards;
+use crate::qdl::loader::family_for_soc;
+use crate::qdl::QdlStorage;
+
+/// A board's QDL facts, resolved from the API or the bundled fallback. Paths are
+/// family-relative; digests are present only when the API supplied them.
+pub struct ResolvedQdl {
+    pub family: String,
+    pub storage: QdlStorage,
+    pub loader_rel: Option<String>,
+    pub provision_rel: Option<String>,
+    pub loader_sha256: Option<String>,
+    pub provision_sha256: Option<String>,
+}
+
+fn from_api(q: ApiQdl) -> Option<ResolvedQdl> {
+    Some(ResolvedQdl {
+        storage: QdlStorage::from_storage_str(&q.storage)?,
+        family: q.family,
+        loader_rel: q.loader_rel,
+        provision_rel: q.provision_rel,
+        loader_sha256: q.loader_sha256,
+        provision_sha256: q.provision_sha256,
+    })
+}
+
+fn bundled(board_slug: &str) -> Option<ResolvedQdl> {
+    let b = boards::find(board_slug)?;
+    Some(ResolvedQdl {
+        family: family_for_soc(b.soc)?.to_string(),
+        storage: b.storage,
+        loader_rel: None,
+        provision_rel: b.provision_rel.map(str::to_string),
+        loader_sha256: None,
+        provision_sha256: None,
+    })
+}
+
+/// Resolve a board's QDL facts: the API `qdl` block first, bundled default as fallback.
+pub async fn resolve(board_slug: &str) -> Option<ResolvedQdl> {
+    if let Some(resolved) = images::fetch_board_qdl(board_slug).await.and_then(from_api) {
+        return Some(resolved);
+    }
+    bundled(board_slug)
+}
+
+/// Verify `bytes` against an expected hex SHA-256 when the API provided one; a
+/// missing digest (bundled/offline path) is accepted.
+pub fn verify_digest(bytes: &[u8], expected: Option<&str>) -> Result<(), String> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    use sha2::{Digest, Sha256};
+    let got = hex::encode(Sha256::digest(bytes));
+    if got.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(format!("SHA-256 mismatch (expected {expected}, got {got})"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_parses_known_values() {
+        assert_eq!(QdlStorage::from_storage_str("ufs"), Some(QdlStorage::Ufs));
+        assert_eq!(QdlStorage::from_storage_str("emmc"), Some(QdlStorage::Emmc));
+        assert_eq!(QdlStorage::from_storage_str("nvme"), None);
+    }
+
+    // Integration check against a local API: `ARMBIAN_API_BASE=http://localhost/api/v1
+    // cargo test resolves_and_fetches_from_local_api -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore = "requires a running API at ARMBIAN_API_BASE"]
+    async fn resolves_and_fetches_from_local_api() {
+        let r = resolve("radxa-dragon-q6a").await.expect("q6a resolves");
+        assert_eq!(r.family, "Kodiak");
+        assert_eq!(r.storage, QdlStorage::Ufs);
+        assert!(r.loader_sha256.is_some(), "API supplies a loader digest");
+
+        let loader = crate::qdl::loader::ensure_loader(&r)
+            .await
+            .expect("loader downloads from the API blob proxy and its digest verifies");
+        assert!(loader.exists());
+
+        use crate::qdl::provision::ProvisionSource;
+        match crate::qdl::provision::ensure_provision_xml(&r).await {
+            ProvisionSource::Ready(p) => assert!(p.exists()),
+            ProvisionSource::Absent => panic!("q6a should declare a provision descriptor"),
+            ProvisionSource::Unavailable(e) => panic!("provision XML unavailable: {e}"),
+        }
+    }
+
+    #[test]
+    fn digest_matches_case_insensitively_and_skips_when_absent() {
+        // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        let empty = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert!(verify_digest(b"", Some(empty)).is_ok());
+        assert!(verify_digest(b"", Some(&empty.to_uppercase())).is_ok());
+        assert!(verify_digest(b"x", Some(empty)).is_err());
+        assert!(verify_digest(b"anything", None).is_ok());
+    }
+}

--- a/src/components/layout/BoardPanel.tsx
+++ b/src/components/layout/BoardPanel.tsx
@@ -105,14 +105,19 @@ export function BoardPanel({ manufacturer, onSelect }: BoardPanelProps) {
               const displayName = stripVendorPrefix(board.name, vendorName);
               const showVendor = !!vendorName;
               const img = board.slug in boardImages ? boardImages[board.slug] : undefined;
+              // A QDL board whose storage this build has no write path for can't be
+              // flashed here; block it at selection instead of failing mid-flash.
+              const needsUpdate = !!board.qdl && !board.qdl.supported;
 
               return (
                 <button
                   key={board.slug}
                   type="button"
-                  className="board-card board-card--enter"
+                  className={`board-card board-card--enter${needsUpdate ? ' board-card--locked' : ''}`}
                   style={{ animationDelay: staggerDelay(index) }}
                   onClick={() => onSelect(board)}
+                  disabled={needsUpdate}
+                  title={needsUpdate ? t('modal.boardUpdateRequiredHint') : undefined}
                 >
                   <div className="board-card__img">
                     {img === undefined ? (
@@ -120,7 +125,10 @@ export function BoardPanel({ manufacturer, onSelect }: BoardPanelProps) {
                     ) : (
                       <BoardImage src={img} alt={board.name} />
                     )}
-                    {tierLabel && <span className={`bp-tier is-${tier}`}>{tierLabel}</span>}
+                    {tierLabel && !needsUpdate && (
+                      <span className={`bp-tier is-${tier}`}>{tierLabel}</span>
+                    )}
+                    {needsUpdate && <span className="bp-lock">{t('modal.boardUpdateRequired')}</span>}
                   </div>
                   <div className="board-card__info">
                     {showVendor && <span className="board-card__vendor">{vendorName}</span>}

--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { ErrorDisplay, DeviceIcon, getDeviceBadge, BoardImage, MarqueeText } from '../shared';
 import type { BlockDevice, AutoconfigProfile, AutoconfigProfilesChangedDetail, FlashMethod } from '../../types';
 import { isEdlMethod } from '../../types';
-import { getBlockDevices, getQdlDevices, getQdlEdlEntry } from '../../hooks/useTauri';
+import { getBlockDevices, getQdlDevices } from '../../hooks/useTauri';
 import { getAutoconfigProfiles, getAllowSystemDevices } from '../../hooks/useSettings';
 import { useAsyncData } from '../../hooks/useAsyncData';
 import { useSkeletonLoading } from '../../hooks/useSkeletonLoading';
@@ -28,8 +28,8 @@ interface DevicePanelProps {
   selectedDevice: BlockDevice | null;
   /** Flash method for the selected image ("block", "qdl", or "qdl-ufs"). */
   flashMethod?: FlashMethod;
-  /** Selected board slug, used to pick the right EDL-entry hint (button vs jumper). */
-  boardSlug?: string;
+  /** EDL-entry hint ("button"/"jumper") for the selected board, drives the QDL instructions. */
+  edlEntry?: string | null;
   /** Upstream selections (manufacturer/board/OS) shown in the confirm summary. */
   summary?: { label: string; value: string }[];
   /** Cached board photo shown at the top of the confirm summary. */
@@ -45,7 +45,7 @@ export function DevicePanel({
   onCancel,
   selectedDevice,
   flashMethod,
-  boardSlug,
+  edlEntry,
   summary = [],
   boardImage,
   supportsAutoconfig = true,
@@ -70,11 +70,6 @@ export function DevicePanel({
   // Both QDL (TAR) and UFS images flash over EDL, so they share device detection (getQdlDevices).
   const isQdlMode = isEdlMethod(flashMethod);
 
-  // EDL-entry method (button vs jumper) comes from the backend board registry.
-  const { data: edlEntry } = useAsyncData<string | null>(
-    () => (isQdlMode && boardSlug ? getQdlEdlEntry(boardSlug) : Promise.resolve(null)),
-    [isQdlMode, boardSlug]
-  );
   // Autoconfig profiles apply to Armbian images (both sd/.img.xz and QDL); hidden for generic custom images.
   const showAutoconfig = supportsAutoconfig;
 

--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -263,7 +263,7 @@ export function HomePage({
   const renderDevicePanel = () => (
     <DevicePanel
       flashMethod={selectedImage ? deriveFlashMethod(selectedImage) : undefined}
-      boardSlug={selectedBoard?.slug}
+      edlEntry={selectedBoard?.qdl?.edl_entry ?? null}
       summary={deviceSummary}
       boardImage={boardImage}
       selectedDevice={selectedDevice}

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -245,8 +245,3 @@ export async function flashQdlUfsImage(
 export async function checkIsQdlImage(imagePath: string): Promise<boolean> {
   return invoke('check_is_qdl_image', { imagePath });
 }
-
-/** EDL-entry method ("button" or "jumper") for a board, or null when unknown */
-export async function getQdlEdlEntry(boardSlug: string): Promise<string | null> {
-  return invoke('get_qdl_edl_entry', { boardSlug });
-}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -72,6 +72,8 @@
     "searchBoard": "Boards suchen...",
     "noManufacturers": "Keine Hersteller gefunden",
     "noBoards": "Keine Boards gefunden",
+    "boardUpdateRequired": "Update erforderlich",
+    "boardUpdateRequiredHint": "Dieses Board wird von dieser Version von Armbian Imager nicht unterstützt. Bitte aktualisieren.",
     "noImages": "Keine Images gefunden",
     "noDevices": "Keine Geräte gefunden",
     "promoted": "Empfohlen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,6 +72,8 @@
     "searchBoard": "Search boards...",
     "noManufacturers": "No manufacturers found",
     "noBoards": "No boards found",
+    "boardUpdateRequired": "Update required",
+    "boardUpdateRequiredHint": "This board isn't supported by this version of Armbian Imager. Please update.",
     "noImages": "No images found",
     "noDevices": "No devices found",
     "promoted": "Recommended",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -72,6 +72,8 @@
     "searchBoard": "Buscar placas...",
     "noManufacturers": "No se encontraron fabricantes",
     "noBoards": "No se encontraron placas",
+    "boardUpdateRequired": "Actualización necesaria",
+    "boardUpdateRequiredHint": "Esta placa no es compatible con esta versión de Armbian Imager. Actualiza la aplicación.",
     "noImages": "No se encontraron imágenes",
     "noDevices": "No se encontraron dispositivos",
     "promoted": "Recomendado",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -72,6 +72,8 @@
     "searchBoard": "Rechercher des cartes...",
     "noManufacturers": "Aucun fabricant trouvé",
     "noBoards": "Aucune carte trouvée",
+    "boardUpdateRequired": "Mise à jour requise",
+    "boardUpdateRequiredHint": "Cette carte n'est pas prise en charge par cette version d'Armbian Imager. Veuillez mettre à jour.",
     "noImages": "Aucune image trouvée",
     "noDevices": "Aucun périphérique trouvé",
     "promoted": "Recommandé",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -72,6 +72,8 @@
     "searchBoard": "Pretraži ploče...",
     "noManufacturers": "Nema pronađenih proizvođača",
     "noBoards": "Nema pronađenih ploča",
+    "boardUpdateRequired": "Potrebna nadogradnja",
+    "boardUpdateRequiredHint": "Ova ploča nije podržana u ovoj verziji Armbian Imagera. Ažurirajte aplikaciju.",
     "noImages": "Nema pronađenih slika",
     "noDevices": "Nema pronađenih uređaja",
     "promoted": "Preporučeno",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -72,6 +72,8 @@
     "searchBoard": "Cerca schede...",
     "noManufacturers": "Nessun produttore trovato",
     "noBoards": "Nessuna scheda trovata",
+    "boardUpdateRequired": "Aggiornamento richiesto",
+    "boardUpdateRequiredHint": "Questa scheda non è supportata da questa versione di Armbian Imager. Aggiorna l'app.",
     "noImages": "Nessuna immagine trovata",
     "noDevices": "Nessun dispositivo trovato",
     "promoted": "Consigliato",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -72,6 +72,8 @@
     "searchBoard": "ボードを検索...",
     "noManufacturers": "メーカーが見つかりません",
     "noBoards": "ボードが見つかりません",
+    "boardUpdateRequired": "更新が必要",
+    "boardUpdateRequiredHint": "このボードはこのバージョンの Armbian Imager ではサポートされていません。更新してください。",
     "noImages": "イメージが見つかりません",
     "noDevices": "デバイスが見つかりません",
     "promoted": "おすすめ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -72,6 +72,8 @@
     "searchBoard": "보드 검색...",
     "noManufacturers": "제조사를 찾을 수 없습니다",
     "noBoards": "보드를 찾을 수 없습니다",
+    "boardUpdateRequired": "업데이트 필요",
+    "boardUpdateRequiredHint": "이 보드는 이 버전의 Armbian Imager에서 지원되지 않습니다. 업데이트하세요.",
     "noImages": "이미지를 찾을 수 없습니다",
     "noDevices": "장치를 찾을 수 없습니다",
     "promoted": "추천",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -72,6 +72,8 @@
     "searchBoard": "Zoek boards...",
     "noManufacturers": "Geen fabrikanten gevonden",
     "noBoards": "Geen boards gevonden",
+    "boardUpdateRequired": "Update vereist",
+    "boardUpdateRequiredHint": "Dit board wordt niet ondersteund door deze versie van Armbian Imager. Werk de app bij.",
     "noImages": "Geen images gevonden",
     "noDevices": "Geen apparaten gevonden",
     "promoted": "Aanbevolen",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -72,6 +72,8 @@
     "searchBoard": "Szukaj płytek...",
     "noManufacturers": "Nie znaleziono producentów",
     "noBoards": "Nie znaleziono płytek",
+    "boardUpdateRequired": "Wymagana aktualizacja",
+    "boardUpdateRequiredHint": "Ta płytka nie jest obsługiwana przez tę wersję Armbian Imager. Zaktualizuj aplikację.",
     "noImages": "Nie znaleziono obrazów",
     "noDevices": "Nie znaleziono urządzeń",
     "promoted": "Polecane",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -72,6 +72,8 @@
     "searchBoard": "Buscar placas...",
     "noManufacturers": "Nenhum fabricante encontrado",
     "noBoards": "Nenhuma placa encontrada",
+    "boardUpdateRequired": "Atualização necessária",
+    "boardUpdateRequiredHint": "Esta placa não é compatível com esta versão do Armbian Imager. Atualize o aplicativo.",
     "noImages": "Nenhuma imagem encontrada",
     "noDevices": "Nenhum dispositivo encontrado",
     "promoted": "Recomendado",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -72,6 +72,8 @@
     "searchBoard": "Procurar placas...",
     "noManufacturers": "Nenhum fabricante encontrado",
     "noBoards": "Nenhuma placa encontrada",
+    "boardUpdateRequired": "Atualização necessária",
+    "boardUpdateRequiredHint": "Esta placa não é suportada por esta versão do Armbian Imager. Atualize a aplicação.",
     "noImages": "Nenhuma imagem encontrada",
     "noDevices": "Nenhum dispositivo encontrado",
     "promoted": "Recomendado",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -72,6 +72,8 @@
     "searchBoard": "Поиск плат...",
     "noManufacturers": "Производители не найдены",
     "noBoards": "Платы не найдены",
+    "boardUpdateRequired": "Требуется обновление",
+    "boardUpdateRequiredHint": "Эта плата не поддерживается этой версией Armbian Imager. Обновите приложение.",
     "noImages": "Образы не найдены",
     "noDevices": "Устройства не найдены",
     "promoted": "Рекомендуется",

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -72,6 +72,8 @@
     "searchBoard": "Išči plošče...",
     "noManufacturers": "Proizvajalcev ni mogoče najti",
     "noBoards": "Plošč ni mogoče najti",
+    "boardUpdateRequired": "Potrebna posodobitev",
+    "boardUpdateRequiredHint": "Ta plošča ni podprta v tej različici Armbian Imagerja. Posodobite aplikacijo.",
     "noImages": "Slik ni mogoče najti",
     "noDevices": "Naprav ni mogoče najti",
     "promoted": "Priporočeno",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -72,6 +72,8 @@
     "searchBoard": "Sök kort...",
     "noManufacturers": "Inga tillverkare hittades",
     "noBoards": "Inga kort hittades",
+    "boardUpdateRequired": "Uppdatering krävs",
+    "boardUpdateRequiredHint": "Det här kortet stöds inte av den här versionen av Armbian Imager. Uppdatera appen.",
     "noImages": "Inga avbildningar hittades",
     "noDevices": "Inga enheter hittades",
     "promoted": "Rekommenderad",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -72,6 +72,8 @@
     "searchBoard": "Kart ara...",
     "noManufacturers": "Üretici bulunamadı",
     "noBoards": "Kart bulunamadı",
+    "boardUpdateRequired": "Güncelleme gerekli",
+    "boardUpdateRequiredHint": "Bu kart bu Armbian Imager sürümü tarafından desteklenmiyor. Lütfen güncelleyin.",
     "noImages": "İmaj bulunamadı",
     "noDevices": "Cihaz bulunamadı",
     "promoted": "Önerilen",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -72,6 +72,8 @@
     "searchBoard": "Пошук плат...",
     "noManufacturers": "Виробників не знайдено",
     "noBoards": "Плат не знайдено",
+    "boardUpdateRequired": "Потрібне оновлення",
+    "boardUpdateRequiredHint": "Ця плата не підтримується цією версією Armbian Imager. Оновіть застосунок.",
     "noImages": "Образів не знайдено",
     "noDevices": "Пристроїв не знайдено",
     "promoted": "Рекомендовані",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -72,6 +72,8 @@
     "searchBoard": "搜索开发板……",
     "noManufacturers": "未找到制造商",
     "noBoards": "未找到开发板",
+    "boardUpdateRequired": "需要更新",
+    "boardUpdateRequiredHint": "此版本的 Armbian Imager 不支持此开发板。请更新。",
     "noImages": "未找到镜像",
     "noDevices": "未找到设备",
     "promoted": "推荐",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2115,6 +2115,30 @@
   box-shadow: 0 0 12px rgba(212, 175, 55, 0.4);
 }
 
+.bp-lock {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  background: #f59e0b;
+  color: #000;
+}
+
+.board-card--locked {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.board-card--locked:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 .board-card__info {
   flex: 1;
   display: flex;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,16 @@ export interface BoardInfo {
   architecture?: string;
   /** Short board description */
   summary?: string;
+  /** QDL/EDL flashing metadata, present only for Qualcomm EDL boards */
+  qdl?: BoardQdl | null;
+}
+
+/** Slim QDL support info served with a board; `supported` drives the UI gate. */
+export interface BoardQdl {
+  /** Whether this build has a write path for the board's QDL storage. */
+  supported: boolean;
+  /** EDL-entry hint ("button"/"jumper") for the on-screen QDL instructions. */
+  edl_entry: string;
 }
 
 export interface ImageInfo {


### PR DESCRIPTION
Moves the QDL board registry off a hardcoded Rust table onto the API's `qdl` block, so adding a Qualcomm EDL board becomes a single JSON entry in the website enrichments with no imager release.

The firehose loader and UFS provisioning descriptor are fetched from the API blob proxy, cached under the app's loaders dir, and re-verified against the API's SHA-256 on every use, so a changed blob on the server re-downloads instead of serving a stale copy. When the API carries no `qdl` block (offline, or an older API), a small bundled table still covers the current boards.

Support is gated on whether this build actually has a write path for a board's storage rather than on a version number. A board whose storage this build can't flash shows an "update required" state and can't be selected; everything current (UFS, eMMC) stays flashable.

The website side (the schema `qdl` block, the blob proxy, and the enrichments) is already live in prod.
