### PR TITLE
feat: flash locally-built UFS images over QDL

### DIFF
--- a/src-tauri/src/commands/custom_image.rs
+++ b/src-tauri/src/commands/custom_image.rs
@@ -171,51 +171,55 @@ pub async fn delete_decompressed_custom_image(image_path: String) -> Result<(), 
     Ok(())
 }
 
-/// Check whether a custom image is a QDL archive (TAR containing rawprogram0.xml
-/// and prog_firehose_ddr.elf). Non-TAR files like .img return false, not an error.
-#[tauri::command]
-pub async fn check_is_qdl_image(image_path: String) -> Result<bool, String> {
-    let path = PathBuf::from(&image_path);
+/// Whether a file is a QDL TAR archive (needs both rawprogram0.xml and prog_firehose_ddr.elf,
+/// so a plain .tar.gz rootfs doesn't count). Non-TAR files return false.
+fn is_qdl_image_path(image_path: &str) -> bool {
+    let path = PathBuf::from(image_path);
     let filename = path
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .to_lowercase();
 
-    // Plain .tar: cheap to inspect every entry.
-    if filename.ends_with(".tar") {
-        log_debug!(
-            "custom_image",
-            "Checking plain TAR for QDL structure: {}",
-            image_path
-        );
-        let reader = match open_tar_reader(&path) {
-            Ok(r) => r,
-            Err(_) => return Ok(false),
+    if filename.ends_with(".tar") || filename.contains(".tar.") {
+        return match open_tar_reader(&path) {
+            Ok(reader) => check_tar_for_qdl(reader),
+            Err(_) => false,
         };
-        let has_qdl = check_tar_for_qdl(reader);
-        log_debug!("custom_image", "Archive has QDL structure: {}", has_qdl);
-        return Ok(has_qdl);
     }
 
-    // Compressed TAR: QDL requires BOTH rawprogram0.xml and prog_firehose_ddr.elf, so scan entries
-    // rather than sniff a flash/ dir or disk-sdcard.img name (a generic .tar.gz rootfs is NOT QDL).
-    if filename.contains(".tar.") {
-        log_debug!(
-            "custom_image",
-            "Checking compressed TAR for QDL structure: {}",
-            image_path
-        );
-        let reader = match open_tar_reader(&path) {
-            Ok(r) => r,
-            Err(_) => return Ok(false),
-        };
-        let has_qdl = check_tar_for_qdl(reader);
-        log_debug!("custom_image", "QDL structure detected: {}", has_qdl);
-        return Ok(has_qdl);
-    }
+    false
+}
 
-    Ok(false)
+/// One-shot classification of a picked image: matched board, whether it's a QDL TAR, and the
+/// slug for a UFS build. Lets the frontend read the file once instead of three round-trips.
+#[derive(Debug, Serialize)]
+pub struct CustomImageClassification {
+    pub board: Option<BoardInfo>,
+    pub is_qdl: bool,
+    pub ufs_board_slug: Option<String>,
+}
+
+#[tauri::command]
+pub async fn classify_custom_image(
+    path: String,
+    state: State<'_, AppState>,
+) -> Result<CustomImageClassification, String> {
+    let filename = std::path::Path::new(&path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&path);
+
+    // Board detection is best-effort (may hit the API); a failure must not sink the rest.
+    let board = match_board_from_filename(filename, &state)
+        .await
+        .unwrap_or(None);
+
+    Ok(CustomImageClassification {
+        board,
+        is_qdl: is_qdl_image_path(&path),
+        ufs_board_slug: crate::qdl::boards::ufs_board_slug_for_filename(filename),
+    })
 }
 
 /// Scan a TAR archive reader for QDL-required files
@@ -261,13 +265,22 @@ pub async fn detect_board_from_filename(
     filename: String,
     state: State<'_, AppState>,
 ) -> Result<Option<BoardInfo>, String> {
+    match_board_from_filename(&filename, &state).await
+}
+
+/// Shared board-matching core: parse the filename, normalize the slug, and match the API list
+/// (loaded on first use). Reused by `detect_board_from_filename` and `classify_custom_image`.
+async fn match_board_from_filename(
+    filename: &str,
+    state: &AppState,
+) -> Result<Option<BoardInfo>, String> {
     log_debug!(
         "custom_image",
         "Starting board detection from filename: {}",
         filename
     );
 
-    let path = PathBuf::from(&filename);
+    let path = PathBuf::from(filename);
     let filename_only = path
         .file_name()
         .and_then(|n| n.to_str())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -168,7 +168,7 @@ fn main() {
             commands::custom_image::decompress_custom_image,
             commands::custom_image::delete_decompressed_custom_image,
             commands::custom_image::detect_board_from_filename,
-            commands::custom_image::check_is_qdl_image,
+            commands::custom_image::classify_custom_image,
             commands::system::open_url,
             commands::system::get_system_locale,
             commands::system::log_from_frontend,

--- a/src-tauri/src/qdl/boards.rs
+++ b/src-tauri/src/qdl/boards.rs
@@ -1,7 +1,11 @@
 //! Bundled fallback registry of per-board QDL/EDL facts, used when the Armbian API
 //! carries no `qdl` block for a board (offline, older API). The API is the primary source.
 
+use std::path::Path;
+
+use super::UFS_MARKERS;
 use crate::qdl::QdlStorage;
+use crate::utils::{normalize_slug, parse_armbian_filename};
 
 pub struct QdlBoard {
     /// Matched case-insensitively as a substring of the board slug.
@@ -32,6 +36,25 @@ pub fn find(board_slug: &str) -> Option<&'static QdlBoard> {
     QDL_BOARDS.iter().find(|b| slug.contains(b.slug_token))
 }
 
+/// Normalized slug if `filename` is a UFS build of a UFS-capable QDL board, else None.
+pub fn ufs_board_slug_for_filename(filename: &str) -> Option<String> {
+    let basename = Path::new(filename)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(filename);
+    let parsed = parse_armbian_filename(basename)?;
+
+    // The UFS suffix lives in the variant field; fall back to the whole name if absent.
+    let variant = parsed.desktop.as_deref().unwrap_or(basename).to_lowercase();
+    if !UFS_MARKERS.iter().any(|m| variant.contains(m)) {
+        return None;
+    }
+
+    let slug = normalize_slug(&parsed.board_slug);
+    find(&slug).filter(|b| b.storage == QdlStorage::Ufs)?;
+    Some(slug)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,5 +65,49 @@ mod tests {
         assert_eq!(b.soc, "QCS6490");
         assert!(b.provision_rel.is_some());
         assert!(find("orangepi-5").is_none());
+        assert!(find("arduino-uno-q")
+            .expect("registered")
+            .provision_rel
+            .is_none());
+    }
+
+    #[test]
+    fn ufs_marker_and_capable_board_is_ufs() {
+        assert_eq!(
+            ufs_board_slug_for_filename(
+                "Armbian-unofficial_26.08.0-trunk_Radxa-dragon-q6a_resolute_edge_7.1.3_gnome-ufs_desktop.img",
+            ),
+            Some("radxa-dragon-q6a".to_string())
+        );
+    }
+
+    #[test]
+    fn ufs_marker_survives_compression_ext() {
+        assert!(ufs_board_slug_for_filename(
+            "Armbian-unofficial_26.08.0-trunk_Radxa-dragon-q6a_resolute_edge_7.1.3_gnome-ufs_desktop.img.xz",
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn sd_variant_of_ufs_board_is_not_ufs() {
+        assert!(ufs_board_slug_for_filename(
+            "Armbian-unofficial_26.08.0-trunk_Radxa-dragon-q6a_resolute_edge_7.1.3_gnome_desktop.img",
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn ufs_marker_on_non_ufs_board_is_none() {
+        // arduino-uno-q storage is eMMC, not UFS => not a raw-UFS target.
+        assert!(ufs_board_slug_for_filename(
+            "Armbian_26.02.0_Arduino-uno-q_trixie_edge_6.19.4_minimal-ufs.img",
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn non_armbian_name_is_none() {
+        assert!(ufs_board_slug_for_filename("ubuntu-24.04-ufs.img").is_none());
     }
 }

--- a/src-tauri/src/qdl/mod.rs
+++ b/src-tauri/src/qdl/mod.rs
@@ -20,6 +20,9 @@ pub const EDL_PID: u16 = 0x9008;
 pub const SECTOR_SIZE_EMMC: usize = 512;
 pub const SECTOR_SIZE_UFS: usize = 4096;
 
+/// Filename variant markers identifying a UFS build (vs the SD variant of the same board).
+pub const UFS_MARKERS: [&str; 2] = ["-ufs", "_ufs"];
+
 /// Storage backend for a QDL flash, mapping to its Firehose storage type and sector size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QdlStorage {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Header, HomePage, WelcomePage } from './components/layout';
 import { ArmbianBoardModal } from './components/modals';
 import { FlashProgress } from './components/flash';
 import { CacheManagerModal } from './components/settings';
-import { selectCustomImage, detectBoardFromFilename, logInfo, logWarn, getArmbianRelease, getBoards, getSystemInfo, getCachedBoardImage, checkNeedsDecompression, decompressCustomImage, checkIsQdlImage } from './hooks/useTauri';
+import { selectCustomImage, detectBoardFromFilename, classifyCustomImage, logInfo, logWarn, getArmbianRelease, getBoards, getSystemInfo, getCachedBoardImage, checkNeedsDecompression, decompressCustomImage } from './hooks/useTauri';
 import { useDeviceMonitor } from './hooks/useDeviceMonitor';
 import { useConnectivity } from './hooks/useConnectivity';
 import { ToastProvider, useToasts } from './hooks/useToasts';
@@ -370,28 +370,23 @@ function AppContent() {
     try {
       const result = await selectCustomImage();
       if (result) {
-        let detectedBoard: BoardInfo | null = null;
-        try {
-          detectedBoard = await detectBoardFromFilename(result.name);
-          if (detectedBoard) {
-            logInfo('app', `Detected board from filename: ${detectedBoard.name} (${detectedBoard.slug})`);
-          }
-        } catch (err) {
-          // Ignore detection errors, fall back to generic
-          logWarn('app', `Failed to detect board from filename: ${err}`);
+        // One backend call classifies the picked file: matched board, QDL TAR, and UFS build slug.
+        const { board: detectedBoard, is_qdl: isQdl, ufs_board_slug: ufsBoardSlug } =
+          await classifyCustomImage(result.path).catch(() => ({
+            board: null,
+            is_qdl: false,
+            ufs_board_slug: null,
+          }));
+        if (detectedBoard) {
+          logInfo('app', `Detected board from filename: ${detectedBoard.name} (${detectedBoard.slug})`);
         }
-
-        // QDL (Qualcomm EDL) TAR archives flash differently than block images
-        let flashMethod = 'block';
-        try {
-          const isQdl = await checkIsQdlImage(result.path);
-          if (isQdl) {
-            flashMethod = 'qdl';
-            logInfo('app', `Custom image detected as QDL archive: ${result.name}`);
-          }
-        } catch {
-          // Default to block on detection failure
+        if (isQdl) {
+          logInfo('app', `Custom image detected as QDL archive: ${result.name}`);
         }
+        if (ufsBoardSlug) {
+          logInfo('app', `Custom image detected as UFS: ${result.name} (board ${ufsBoardSlug})`);
+        }
+        const flashMethod = isQdl ? 'qdl' : 'block';
 
         const customImage: ImageInfo = {
           release: 'Custom',
@@ -407,6 +402,7 @@ function AppContent() {
           file_size: result.size,
           stability: 'stable',
           format: flashMethod,
+          storage: ufsBoardSlug ? 'ufs' : null,
           companions: [],
           display_variants: [],
           is_custom: true,
@@ -415,9 +411,9 @@ function AppContent() {
 
         resetSelectionsFrom('manufacturer');
 
-        // Use detected board if found, otherwise a generic custom board
-        const displayBoard = detectedBoard || {
-          slug: SLUGS.CUSTOM,
+        // API-matched board, else a generic one carrying the UFS registry slug (backend resolves the rest).
+        const displayBoard: BoardInfo = detectedBoard ?? {
+          slug: ufsBoardSlug ?? SLUGS.CUSTOM,
           name: t('custom.customImage'),
           vendor: SLUGS.CUSTOM,
           vendor_name: 'Custom',

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, ArmbianReleaseInfo, CachedImageInfo, CacheBreakdown, QdlDevice, VendorInfo, AutoconfigConfig } from '../types';
+import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, CustomImageClassification, ArmbianReleaseInfo, CachedImageInfo, CacheBreakdown, QdlDevice, VendorInfo, AutoconfigConfig } from '../types';
 
 export async function getBoards(): Promise<BoardInfo[]> {
   return invoke('get_boards');
@@ -86,6 +86,11 @@ export async function deleteDecompressedCustomImage(imagePath: string): Promise<
 /** Detect board info from an Armbian image filename, or null if no match */
 export async function detectBoardFromFilename(filename: string): Promise<BoardInfo | null> {
   return invoke('detect_board_from_filename', { filename });
+}
+
+/** Classify a picked custom image in one call: matched board, QDL TAR flag, and UFS build slug */
+export async function classifyCustomImage(path: string): Promise<CustomImageClassification> {
+  return invoke('classify_custom_image', { path });
 }
 
 // Re-export CustomImageInfo for backward compatibility
@@ -239,9 +244,4 @@ export async function flashQdlUfsImage(
   autoconfig?: AutoconfigConfig | null
 ): Promise<void> {
   return invoke('flash_qdl_ufs_image', { imagePath, soc, boardSlug, serial, autoconfig });
-}
-
-/** Check whether a TAR file is a QDL flash archive (has rawprogram0.xml + firehose ELF) */
-export async function checkIsQdlImage(imagePath: string): Promise<boolean> {
-  return invoke('check_is_qdl_image', { imagePath });
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -183,6 +183,14 @@ export interface CustomImageInfo {
   size: number;
 }
 
+/** One-shot classification of a picked custom image (board + QDL TAR + UFS build slug) */
+export interface CustomImageClassification {
+  board: BoardInfo | null;
+  is_qdl: boolean;
+  /** Board slug when the file is a UFS build of a UFS-capable QDL board, else null */
+  ufs_board_slug: string | null;
+}
+
 /** Cached image metadata from the backend cache directory */
 export interface CachedImageInfo {
   filename: string;


### PR DESCRIPTION
A locally-built Armbian UFS image (say a Radxa Dragon Q6A `…_gnome-ufs_desktop.img`) used to get flashed as a plain block write. Custom images only ever checked for the TAR-based QDL format and never carried a storage target, so the raw-UFS path was unreachable for them.

Now the imager reads the `-ufs` marker from the filename and checks it against the QDL board registry (only boards with a known Firehose loader and provisioning descriptor pass), then flashes it over the existing raw-UFS path. While I was in there I collapsed the board, QDL-TAR and UFS checks into a single `classify_custom_image` call, so a picked file gets read once instead of over three separate calls.

Unit tests cover the filename classifier, and I've verified the full flash end to end on a real Dragon Q6A.
