### PR TITLE
fix(ci): un-bundle libwayland from the AppImage to stop the EGL abort (#67)

### DIFF
--- a/.github/workflows/maintenance-build.yml
+++ b/.github/workflows/maintenance-build.yml
@@ -95,6 +95,11 @@ jobs:
       - name: Build Tauri app
         run: cargo tauri build --bundles deb,appimage
 
+      # See scripts/build/appimage-unbundle-wayland.sh — bundled libwayland aborts
+      # EGL init on the user's Wayland session (issue #67).
+      - name: Un-bundle libwayland from AppImage (#67)
+        run: ./scripts/build/appimage-unbundle-wayland.sh
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -159,6 +164,11 @@ jobs:
 
       - name: Build Tauri app
         run: cargo tauri build --bundles deb,appimage
+
+      # See scripts/build/appimage-unbundle-wayland.sh — bundled libwayland aborts
+      # EGL init on the user's Wayland session (issue #67).
+      - name: Un-bundle libwayland from AppImage (#67)
+        run: ./scripts/build/appimage-unbundle-wayland.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maintenance-pr-check.yml
+++ b/.github/workflows/maintenance-pr-check.yml
@@ -248,6 +248,13 @@ jobs:
       - name: Build application
         run: cargo tauri build --bundles ${{ matrix.bundles }}
 
+      # See scripts/build/appimage-unbundle-wayland.sh — bundled libwayland aborts
+      # EGL init on the user's Wayland session (issue #67). Keeps the AppImage that
+      # reviewers download from this PR usable on modern distros.
+      - name: Un-bundle libwayland from AppImage (#67)
+        if: runner.os == 'Linux'
+        run: ./scripts/build/appimage-unbundle-wayland.sh
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/maintenance-release.yml
+++ b/.github/workflows/maintenance-release.yml
@@ -208,6 +208,13 @@ jobs:
       - name: Build Tauri app
         run: cargo tauri build --bundles "${{ matrix.type.bundles }}"
 
+      # linuxdeploy bundles libwebkit2gtk's transitive libwayland-* into the AppImage;
+      # those are older than the user's Mesa and abort EGL init on Wayland (issue #67).
+      # The script strips them, repacks, and re-signs the updater artifact.
+      - name: Un-bundle libwayland from AppImage (#67)
+        if: ${{ matrix.type.name == 'appimage' }}
+        run: ./scripts/build/appimage-unbundle-wayland.sh
+
       - name: Upload artifacts to GitHub Release
         uses: ncipollo/release-action@v1
         with:

--- a/scripts/build/appimage-unbundle-wayland.sh
+++ b/scripts/build/appimage-unbundle-wayland.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Un-bundle the Wayland client libraries from the freshly built AppImage(s).
+#
+# linuxdeploy pulls libwebkit2gtk's transitive libwayland-{client,cursor,egl,server}
+# into the AppImage. Those copies come from the build container, which is older than
+# the Mesa the *user* is running, so when libEGL_mesa initialises the Wayland platform
+# it hits a protocol/ABI mismatch and aborts:
+#
+#     Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
+#
+# The webview never paints and the window stays blank white. This happens inside EGL
+# display init, before WebKit ever reads WEBKIT_DISABLE_DMABUF_RENDERER, which is why
+# none of the usual WEBKIT_*/GDK_BACKEND/LIBGL_* workarounds have any effect.
+#
+# libwayland — like libGL/libEGL/libgbm/libdrm, which linuxdeploy already excludes —
+# has to come from the running system so it matches the loaded EGL stack. Its soname
+# has been frozen for over a decade, so deferring to the host is safe. Only the
+# AppImage bundles libraries; the .deb links the system libwayland and is unaffected.
+#
+# See: https://github.com/armbian/imager/issues/67
+#
+# Usage: scripts/build/appimage-unbundle-wayland.sh [bundle-dir]
+#
+set -euo pipefail
+
+BUNDLE_DIR="${1:-src-tauri/target/release/bundle/appimage}"
+ARCH="${ARCH:-$(uname -m)}"
+
+if [[ ! -d "$BUNDLE_DIR" ]]; then
+    echo "No AppImage bundle directory at $BUNDLE_DIR — nothing to do."
+    exit 0
+fi
+
+shopt -s nullglob
+APPIMAGES=("$BUNDLE_DIR"/*.AppImage)
+if [[ ${#APPIMAGES[@]} -eq 0 ]]; then
+    echo "No AppImage found in $BUNDLE_DIR — nothing to do."
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+APPIMAGETOOL="$WORK_DIR/appimagetool"
+echo "Fetching appimagetool for $ARCH"
+curl -fsSL -o "$APPIMAGETOOL" \
+    "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+chmod +x "$APPIMAGETOOL"
+
+for APP in "${APPIMAGES[@]}"; do
+    echo "==> Repacking $(basename "$APP") without bundled libwayland"
+
+    EXTRACT_DIR="$WORK_DIR/extract"
+    rm -rf "$EXTRACT_DIR"
+    mkdir -p "$EXTRACT_DIR"
+    # The AppImage runtime extracts itself; no FUSE needed on the runner.
+    (cd "$EXTRACT_DIR" && "$(realpath "$APP")" --appimage-extract >/dev/null)
+
+    # Path-tolerant, and a no-op if a future linuxdeploy stops bundling these.
+    find "$EXTRACT_DIR/squashfs-root" -type f \( \
+        -name 'libwayland-client.so.*' -o \
+        -name 'libwayland-cursor.so.*' -o \
+        -name 'libwayland-egl.so.*' -o \
+        -name 'libwayland-server.so.*' \) -print -delete
+
+    # --appimage-extract-and-run so appimagetool itself doesn't need FUSE either.
+    ARCH="$ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
+        "$EXTRACT_DIR/squashfs-root" "$APP.new" >/dev/null
+    mv -f "$APP.new" "$APP"
+    chmod +x "$APP"
+
+    # Repacking invalidates the updater signature Tauri produced during the build,
+    # so mint a fresh one over the new bytes. Without this the in-app updater would
+    # reject every Linux update.
+    if [[ -f "$APP.sig" ]]; then
+        if [[ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
+            echo "ERROR: $APP.sig exists but TAURI_SIGNING_PRIVATE_KEY is unset;" \
+                 "the AppImage would ship with a stale signature." >&2
+            exit 1
+        fi
+        echo "    re-signing $(basename "$APP")"
+        # `cargo tauri build` accepts the key inline or as a path to a key file, so
+        # accept both here too. Note the `signer` subcommand reads TAURI_PRIVATE_KEY*,
+        # not the TAURI_SIGNING_* names the bundler uses.
+        KEY="$TAURI_SIGNING_PRIVATE_KEY"
+        if [[ -f "$KEY" ]]; then
+            KEY="$(<"$KEY")"
+        fi
+        TAURI_PRIVATE_KEY="$KEY" \
+        TAURI_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
+            cargo tauri signer sign "$APP" >/dev/null
+    fi
+
+    echo "    done — $(basename "$APP") now defers libwayland to the host"
+done


### PR DESCRIPTION
## Summary

Fixes #67 — the Linux AppImage shows a blank white window and logs:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

## Root cause

`linuxdeploy` pulls libwebkit2gtk's transitive `libwayland-{client,cursor,egl,server}` into the AppImage. Those copies come from the Ubuntu 24.04 build environment and are older than the Mesa the *user* is running, so when `libEGL_mesa` initialises the Wayland platform it hits a protocol/ABI mismatch and aborts. The webview never paints.

The abort happens inside EGL display init, **before** WebKit reads any of its environment — which is exactly why `WEBKIT_DISABLE_DMABUF_RENDERER`, `WEBKIT_DISABLE_COMPOSITING_MODE`, `GDK_BACKEND=x11` and `LIBGL_ALWAYS_SOFTWARE` have no effect for the reporters in #67.

## Fix

`libwayland` — like `libGL`/`libEGL`/`libgbm`/`libdrm`, which linuxdeploy already excludes — has to come from the running system so it matches the loaded EGL stack. Its soname has been frozen for over a decade, so deferring to the host is safe.

`scripts/build/appimage-unbundle-wayland.sh` runs after the Tauri build: extract → delete the four `libwayland-*` → repack with `appimagetool` → **re-sign**. It's wired into all three workflows that produce an AppImage (`maintenance-release`, `maintenance-build`, `maintenance-pr-check`).

This is the same thing several people in #67 confirmed by hand (`--appimage-extract`, `rm squashfs-root/usr/lib/*wayland*so*`, run `AppRun`) — just done once at build time so users don't have to.

Only the AppImage bundles libraries; the `.deb` links the system `libwayland` and is unaffected.

### Note on the updater signature

Repacking changes the AppImage bytes, so the `.sig` Tauri emitted during the build no longer matches. The script re-signs with `cargo tauri signer sign`; without that the in-app updater would reject every Linux update. Worth a careful look during review, since it's the one part that can't be exercised without the release signing secret.

(`tauri signer sign` reads `TAURI_PRIVATE_KEY`/`TAURI_PRIVATE_KEY_PASSWORD`, not the `TAURI_SIGNING_*` names the bundler uses — the script maps them, and fails loudly rather than shipping a stale signature if the key is missing.)

## Verification

A/B tested against the published `Armbian.Imager_2.0.2_amd64.AppImage` on Wayland (`XDG_SESSION_TYPE=wayland`), running the script exactly as CI invokes it:

**Stock release — reproduces the bug:**
```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

**After the script — starts and renders:**
```
● main: === Armbian Imager Starting ===
● picture_cache: Pre-populate complete: 436/436 assets processed
● frontend::app: Not running on Armbian system
● frontend::updater: No updates available
```
No EGL error, and the `frontend::*` lines mean the webview actually executed the app.

The script found and removed all four libs, and repacked cleanly:
```
squashfs-root/usr/lib/libwayland-server.so.0
squashfs-root/usr/lib/libwayland-egl.so.1
squashfs-root/usr/lib/libwayland-cursor.so.0
squashfs-root/usr/lib/libwayland-client.so.0
```

CI-side, the Linux job of this PR's own build exercises the script end to end.

## Notes

- No new build dependency: `appimagetool` bundles its own `mksquashfs`.
- Arch-aware (`x86_64` / `aarch64`), so the ARM64 AppImage gets the same treatment.
- Uses `--appimage-extract-and-run` so no FUSE is needed on the runners.
- The `find … -delete` is path-tolerant and a no-op if a future linuxdeploy stops bundling these, so the step won't break the build once it's no longer needed.
- This is narrower than the "build against a newer WebKitGTK" idea floated in #67 — it doesn't change what WebKit version ships, only which `libwayland` gets loaded. The two aren't mutually exclusive.
