### PR TITLE
fix(autoconfig): replace existing preset contents

### DIFF
--- a/crates/armbian-write-conf/Cargo.lock
+++ b/crates/armbian-write-conf/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "ext4-view",
  "gptman",
  "mbrman",
+ "mkext4",
  "tempfile",
 ]
 
@@ -85,6 +86,15 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "darling"
@@ -220,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mkext4"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9b87ba418ec2aace835f39128b6c7a90a9f7f8130da2db95a3e00f94d97be1"
+dependencies = [
+ "crc32c",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +307,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/crates/armbian-write-conf/Cargo.toml
+++ b/crates/armbian-write-conf/Cargo.toml
@@ -12,4 +12,5 @@ mbrman = "0"
 ext4-view = { version = "0.9", features = ["std"] }
 
 [dev-dependencies]
+mkext4 = "0.0.3"
 tempfile = "3"

--- a/crates/armbian-write-conf/tests/overwrite_existing.rs
+++ b/crates/armbian-write-conf/tests/overwrite_existing.rs
@@ -1,0 +1,35 @@
+use armbian_write_conf::write_file_into_bare_ext4_image;
+use mkext4::sink::VecSink;
+use mkext4::{FsBuilder, Options};
+use tempfile::tempdir;
+
+const IMAGE_SIZE: u64 = 16 * 1024 * 1024;
+const SUPERBLOCK_OFFSET: usize = 1024;
+const SUPERBLOCK_SIZE: usize = 1024;
+const GROUP_DESCRIPTOR_SIZE_OFFSET: usize = 0xfe;
+const SUPERBLOCK_CHECKSUM_OFFSET: usize = 0x3fc;
+
+#[test]
+fn shorter_write_replaces_existing_file() {
+    let directory = tempdir().unwrap();
+    let image = directory.path().join("image.img");
+    let builder = FsBuilder::new(Options::new(IMAGE_SIZE, [0x42; 16], 0)).unwrap();
+    let layout = builder.seal().unwrap();
+    let mut sink = VecSink::default();
+    layout.writer(&mut sink).unwrap().finish().unwrap();
+    let superblock = SUPERBLOCK_OFFSET..SUPERBLOCK_OFFSET + SUPERBLOCK_SIZE;
+    let descriptor_size = SUPERBLOCK_OFFSET + GROUP_DESCRIPTOR_SIZE_OFFSET;
+    sink.buf[descriptor_size..descriptor_size + 2].copy_from_slice(&32u16.to_le_bytes());
+    let checksum = mkext4::csum::superblock(&sink.buf[superblock.clone()]);
+    let checksum_offset = SUPERBLOCK_OFFSET + SUPERBLOCK_CHECKSUM_OFFSET;
+    sink.buf[checksum_offset..checksum_offset + 4].copy_from_slice(&checksum.to_le_bytes());
+    std::fs::write(&image, sink.buf).unwrap();
+
+    let initial = vec![b'x'; 420];
+    let replacement = vec![b'y'; 382];
+    write_file_into_bare_ext4_image(&image, "/preset", &initial).unwrap();
+    let report = write_file_into_bare_ext4_image(&image, "/preset", &replacement).unwrap();
+
+    assert_eq!(report.bytes_written, replacement.len());
+    assert!(report.validated);
+}

--- a/crates/armbian-write-conf/vendor/armbian-ext4fs/src/simple_interface/mod.rs
+++ b/crates/armbian-write-conf/vendor/armbian-ext4fs/src/simple_interface/mod.rs
@@ -66,7 +66,16 @@ impl Ext4 {
             create = true;
         }
 
-        self.generic_open(path, &mut parent_inode_num, create, filetype.bits(), &mut 0)
+        let inode = self.generic_open(path, &mut parent_inode_num, create, filetype.bits(), &mut 0)?;
+
+        if iflags & O_TRUNC != 0 {
+            let mut inode_ref = self.get_inode_ref(inode);
+            if inode_ref.inode.size() > 0 {
+                self.truncate_inode(&mut inode_ref, 0)?;
+            }
+        }
+
+        Ok(inode)
     }
 
     /// Create a new directory at the specified path.


### PR DESCRIPTION
Existing ext4 files were opened with w+, but the vendored filesystem ignored O_TRUNC. Shorter presets kept the previous tail and failed validation.

This honors truncation on open and adds a regression test for replacing a 420-byte file with 382 bytes.

Closes #178