### PR TITLE
chore(license): declare GPL-2.0-or-later and add SPDX headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ This is possible thanks to [SignPath Foundation](https://signpath.org?utm_source
 
 Setup, build instructions, and project layout live in [DEVELOPMENT.md](DEVELOPMENT.md).
 
+## License
+
+Armbian Imager is distributed under the GNU General Public License, either version 2 or (at your option) any later version. Version 2 is the floor, so the terms stay compatible with the [Armbian build framework](https://github.com/armbian/build).
+
+SPDX-License-Identifier: `GPL-2.0-or-later`
+
+The full text is in [LICENSE](LICENSE). A few bundled components keep their own terms: the `armbian-write-conf` crate and its vendored `armbian-ext4fs` fork are `MIT`, and the language flag graphics from [Twemoji](https://github.com/jdecked/twemoji) are `CC-BY-4.0`. Per-file details are in [`src-tauri/packaging/copyright`](src-tauri/packaging/copyright).
+
 ---
 
 <p align="center">

--- a/crates/armbian-write-conf/src/detect.rs
+++ b/crates/armbian-write-conf/src/detect.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Partition-scheme detection and ext4 rootfs location for RAW disk images.
 

--- a/crates/armbian-write-conf/src/detect.rs
+++ b/crates/armbian-write-conf/src/detect.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Armbian and Armbian Imager contributors
+
 //! Partition-scheme detection and ext4 rootfs location for RAW disk images.
 
 use std::fs::File;

--- a/crates/armbian-write-conf/src/lib.rs
+++ b/crates/armbian-write-conf/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Armbian and Armbian Imager contributors
+
 //! Write a config file into a RAW disk image's ext4 rootfs in userspace (no mount/privileges), then validate.
 //! Parses partition scheme (GPT/MBR), locates the Linux ext4 rootfs, writes via `armbian-ext4fs`, re-validates read-only with `ext4-view`.
 

--- a/crates/armbian-write-conf/src/lib.rs
+++ b/crates/armbian-write-conf/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Write a config file into a RAW disk image's ext4 rootfs in userspace (no mount/privileges), then validate.
 //! Parses partition scheme (GPT/MBR), locates the Linux ext4 rootfs, writes via `armbian-ext4fs`, re-validates read-only with `ext4-view`.

--- a/crates/armbian-write-conf/src/validate.rs
+++ b/crates/armbian-write-conf/src/validate.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Read-only validation of an ext4 rootfs after a write, using ext4-view (verifies inode + block-group-descriptor
 //! checksums on access), so reading the dest file back and walking the whole tree acts as an e2fsck proxy.

--- a/crates/armbian-write-conf/src/validate.rs
+++ b/crates/armbian-write-conf/src/validate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Armbian and Armbian Imager contributors
+
 //! Read-only validation of an ext4 rootfs after a write, using ext4-view (verifies inode + block-group-descriptor
 //! checksums on access), so reading the dest file back and walking the whole tree acts as an e2fsck proxy.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "armbian-imager",
       "version": "2.0.0",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-fs": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "2.0.0",
   "description": "Flash Armbian OS images to SD cards and USB drives",
+  "license": "GPL-2.0-or-later",
   "author": "Armbian",
   "maintainers": [
     "SuperKali <hello@superkali.me>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "author": "Armbian",
   "maintainers": [
-    "SuperKali <hello@superkali.me>"
+    "Daniele Briguglio <superkali@armbian.com>"
   ],
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,9 @@ description = "Armbian Imager - Flash Armbian OS images to SD cards and USB driv
 authors = ["Armbian", "SuperKali <hello@superkali.me>"]
 edition = "2021"
 rust-version = "1.85.0"
+license = "GPL-2.0-or-later"
+homepage = "https://github.com/armbian/imager"
+repository = "https://github.com/armbian/imager"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "armbian-imager"
 version = "2.0.0"
 description = "Armbian Imager - Flash Armbian OS images to SD cards and USB drives"
-authors = ["Armbian", "SuperKali <hello@superkali.me>"]
+authors = ["Armbian", "Daniele Briguglio <superkali@armbian.com>"]
 edition = "2021"
 rust-version = "1.85.0"
 license = "GPL-2.0-or-later"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 fn main() {
     // Extract Tauri version from Cargo.toml and expose it as a compile-time env var
     println!("cargo:rustc-env=TAURI_VERSION={}", tauri_version());

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 fn main() {
     // Extract Tauri version from Cargo.toml and expose it as a compile-time env var

--- a/src-tauri/packaging/copyright
+++ b/src-tauri/packaging/copyright
@@ -1,0 +1,64 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: armbian-imager
+Upstream-Contact: Armbian <https://github.com/armbian/imager/issues>
+Source: https://github.com/armbian/imager
+
+Files: *
+Copyright: 2025-2026 Armbian and Armbian Imager contributors
+License: GPL-2.0-or-later
+
+Files: crates/armbian-write-conf/*
+Copyright: 2026 Armbian and Armbian Imager contributors
+License: MIT
+
+Files: crates/armbian-write-conf/vendor/armbian-ext4fs/*
+Copyright: 2024 yuoo655 <lenuulan@gmail.com>
+Comment: Vendored fork of ext4_rs v1.3.3, https://github.com/yuoo655/ext4_rs
+License: MIT
+
+Files: src/config/i18n.ts
+Copyright: Twitter, Inc and other contributors
+Comment: The language flag graphics imported here come from Twemoji
+ (https://github.com/jdecked/twemoji) via the @twemoji/svg package and are
+ bundled into the application. Only the graphics are covered by this entry.
+License: CC-BY-4.0
+
+License: GPL-2.0-or-later
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 2 of the License, or (at your option) any later
+ version.
+ .
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ .
+ On Debian systems the full text of the GNU General Public License version 2 can
+ be found in /usr/share/common-licenses/GPL-2.
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: CC-BY-4.0
+ This work is licensed under the Creative Commons Attribution 4.0 International
+ License. You are free to share and adapt the material for any purpose, including
+ commercially, provided that you give appropriate credit, provide a link to the
+ license, and indicate if changes were made.
+ .
+ The full text of the license is available at
+ https://creativecommons.org/licenses/by/4.0/legalcode.

--- a/src-tauri/packaging/copyright
+++ b/src-tauri/packaging/copyright
@@ -2,26 +2,39 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: armbian-imager
 Upstream-Contact: Armbian <https://github.com/armbian/imager/issues>
 Source: https://github.com/armbian/imager
+Comment: The binary bundles the Twemoji flag graphics
+ (https://github.com/jdecked/twemoji) through the @twemoji/svg package. Those
+ graphics are licensed CC-BY-4.0; Twemoji's own code is MIT and is not used here.
 
 Files: *
-Copyright: 2025-2026 Armbian and Armbian Imager contributors
+Copyright: 2025-2026 Daniele Briguglio <superkali@armbian.com>
+License: GPL-2.0-or-later
+
+Files: src/assets/os-logos/index.ts
+ src/config/badges.ts
+ src/config/os-info.ts
+Copyright: 2025-2026 Daniele Briguglio <superkali@armbian.com>
+ 2026 Igor Pecovnik <igor@armbian.com>
+License: GPL-2.0-or-later
+
+Files: src/i18n.ts
+Copyright: 2025-2026 Daniele Briguglio <superkali@armbian.com>
+ 2025 Igor Pecovnik <igor@armbian.com>
+License: GPL-2.0-or-later
+
+Files: src/config/i18n.ts
+Copyright: 2025-2026 Daniele Briguglio <superkali@armbian.com>
+ 2026 Ricardo Pardini <ricardo@pardini.net>
 License: GPL-2.0-or-later
 
 Files: crates/armbian-write-conf/*
-Copyright: 2026 Armbian and Armbian Imager contributors
+Copyright: 2026 Daniele Briguglio <superkali@armbian.com>
 License: MIT
 
 Files: crates/armbian-write-conf/vendor/armbian-ext4fs/*
 Copyright: 2024 yuoo655 <lenuulan@gmail.com>
 Comment: Vendored fork of ext4_rs v1.3.3, https://github.com/yuoo655/ext4_rs
 License: MIT
-
-Files: src/config/i18n.ts
-Copyright: Twitter, Inc and other contributors
-Comment: The language flag graphics imported here come from Twemoji
- (https://github.com/jdecked/twemoji) via the @twemoji/svg package and are
- bundled into the application. Only the graphics are covered by this entry.
-License: CC-BY-4.0
 
 License: GPL-2.0-or-later
  This program is free software; you can redistribute it and/or modify it under
@@ -34,7 +47,8 @@ License: GPL-2.0-or-later
  PARTICULAR PURPOSE. See the GNU General Public License for more details.
  .
  On Debian systems the full text of the GNU General Public License version 2 can
- be found in /usr/share/common-licenses/GPL-2.
+ be found in /usr/share/common-licenses/GPL-2. This package also ships it at
+ /usr/share/doc/armbian-imager/LICENSE.
 
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src-tauri/src/autoconfig.rs
+++ b/src-tauri/src/autoconfig.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Armbian first-boot autoconfig: render a preset (mirrors client-side AutoconfigConfig) and inject it.
 //! [`inject_into_image`] writes it to `/root/.not_logged_in_yet` in the image's ext4 rootfs, consumed on first boot. See https://docs.armbian.com/User-Guide_Autoconfig/.

--- a/src-tauri/src/autoconfig.rs
+++ b/src-tauri/src/autoconfig.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Armbian first-boot autoconfig: render a preset (mirrors client-side AutoconfigConfig) and inject it.
 //! [`inject_into_image`] writes it to `/root/.not_logged_in_yet` in the image's ext4 rootfs, consumed on first boot. See https://docs.armbian.com/User-Guide_Autoconfig/.
 

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Persistent cache for downloaded Armbian images with size limits and LRU
 //! eviction. All operations are guarded by a global Mutex.
 

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Persistent cache for downloaded Armbian images with size limits and LRU
 //! eviction. All operations are guarded by a global Mutex.

--- a/src-tauri/src/commands/board_queries.rs
+++ b/src-tauri/src/commands/board_queries.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Board and image queries: fetch and filter board/image data from the Armbian REST API.
 
 use std::collections::HashSet;

--- a/src-tauri/src/commands/board_queries.rs
+++ b/src-tauri/src/commands/board_queries.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Board and image queries: fetch and filter board/image data from the Armbian REST API.
 

--- a/src-tauri/src/commands/custom_image.rs
+++ b/src-tauri/src/commands/custom_image.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Selection and processing of user-provided custom images.
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/commands/custom_image.rs
+++ b/src-tauri/src/commands/custom_image.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Selection and processing of user-provided custom images.
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Tauri command handlers organized by responsibility.
 
 pub mod board_queries;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Tauri command handlers organized by responsibility.
 

--- a/src-tauri/src/commands/operations.rs
+++ b/src-tauri/src/commands/operations.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Download and flash operations.
 
 use std::path::PathBuf;

--- a/src-tauri/src/commands/operations.rs
+++ b/src-tauri/src/commands/operations.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Download and flash operations.
 

--- a/src-tauri/src/commands/progress.rs
+++ b/src-tauri/src/commands/progress.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Progress tracking: download and flash progress reporting.
 

--- a/src-tauri/src/commands/progress.rs
+++ b/src-tauri/src/commands/progress.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Progress tracking: download and flash progress reporting.
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/commands/qdl_operations.rs
+++ b/src-tauri/src/commands/qdl_operations.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Tauri command handlers for QDL (Qualcomm EDL) device detection and flashing.
 
 use std::path::PathBuf;

--- a/src-tauri/src/commands/qdl_operations.rs
+++ b/src-tauri/src/commands/qdl_operations.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Tauri command handlers for QDL (Qualcomm EDL) device detection and flashing.
 

--- a/src-tauri/src/commands/scraping.rs
+++ b/src-tauri/src/commands/scraping.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Asset caching: serves board images and vendor logos from the local picture
 //! cache as base64 data URIs, downloading from the Armbian API on first access.
 

--- a/src-tauri/src/commands/scraping.rs
+++ b/src-tauri/src/commands/scraping.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Asset caching: serves board images and vendor logos from the local picture
 //! cache as base64 data URIs, downloading from the Armbian API on first access.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Settings persistence (theme, language, cache, etc.) via the Tauri Store plugin.
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Settings persistence (theme, language, cache, etc.) via the Tauri Store plugin.
 
 use crate::log_info;

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Defines the shared application state used across commands.
 

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Defines the shared application state used across commands.
 
 use std::sync::Arc;

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Platform-specific system utilities: opening URLs, locale and Armbian detection.
 
 use crate::{log_debug, log_info, log_warn};

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Platform-specific system utilities: opening URLs, locale and Armbian detection.
 

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 use serde::{Deserialize, Serialize};
 use tauri::command;
 

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 use serde::{Deserialize, Serialize};
 use tauri::command;

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Centralized hard-coded values, URLs, and configuration options.
 //! Allows dead_code: some consts are only referenced under platform cfg blocks.

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Centralized hard-coded values, URLs, and configuration options.
 //! Allows dead_code: some consts are only referenced under platform cfg blocks.
 

--- a/src-tauri/src/decompress.rs
+++ b/src-tauri/src/decompress.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Decompressing image files (XZ, GZ, BZ2, ZST) using native Rust libraries,
 //! with multi-threading for XZ.

--- a/src-tauri/src/decompress.rs
+++ b/src-tauri/src/decompress.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Decompressing image files (XZ, GZ, BZ2, ZST) using native Rust libraries,
 //! with multi-threading for XZ.
 

--- a/src-tauri/src/devices/linux.rs
+++ b/src-tauri/src/devices/linux.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Linux device detection via lsblk.
 

--- a/src-tauri/src/devices/linux.rs
+++ b/src-tauri/src/devices/linux.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Linux device detection via lsblk.
 
 use std::fs;

--- a/src-tauri/src/devices/macos.rs
+++ b/src-tauri/src/devices/macos.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! macOS device detection via the native DiskArbitration framework.
 
 use std::sync::{Mutex, OnceLock};

--- a/src-tauri/src/devices/macos.rs
+++ b/src-tauri/src/devices/macos.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! macOS device detection via the native DiskArbitration framework.
 

--- a/src-tauri/src/devices/mod.rs
+++ b/src-tauri/src/devices/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Platform-specific block device detection.
 
 mod types;

--- a/src-tauri/src/devices/mod.rs
+++ b/src-tauri/src/devices/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Platform-specific block device detection.
 

--- a/src-tauri/src/devices/types.rs
+++ b/src-tauri/src/devices/types.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Device types and shared helpers for block device representation.
 

--- a/src-tauri/src/devices/types.rs
+++ b/src-tauri/src/devices/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Device types and shared helpers for block device representation.
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/devices/windows.rs
+++ b/src-tauri/src/devices/windows.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Windows device detection using native Win32 APIs
 
 use std::ffi::c_void;

--- a/src-tauri/src/devices/windows.rs
+++ b/src-tauri/src/devices/windows.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Windows device detection using native Win32 APIs
 

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Downloading Armbian images from the web.
 

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Downloading Armbian images from the web.
 
 use futures_util::StreamExt;

--- a/src-tauri/src/flash/linux/mod.rs
+++ b/src-tauri/src/flash/linux/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Linux-specific flash implementation. Uses UDisks2 (polkit) for device
 //! access, falling back to a direct root open.

--- a/src-tauri/src/flash/linux/mod.rs
+++ b/src-tauri/src/flash/linux/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Linux-specific flash implementation. Uses UDisks2 (polkit) for device
 //! access, falling back to a direct root open.
 

--- a/src-tauri/src/flash/linux/privileges.rs
+++ b/src-tauri/src/flash/linux/privileges.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Linux privilege management. UDisks2/polkit prompts when the device is opened,
 //! so the app can run as a normal user.

--- a/src-tauri/src/flash/linux/privileges.rs
+++ b/src-tauri/src/flash/linux/privileges.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Linux privilege management. UDisks2/polkit prompts when the device is opened,
 //! so the app can run as a normal user.
 

--- a/src-tauri/src/flash/linux/writer.rs
+++ b/src-tauri/src/flash/linux/writer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Linux device writer. Uses UDisks2 (polkit auth) so the app can run as a
 //! normal user, falling back to a direct open when UDisks2 is unavailable.

--- a/src-tauri/src/flash/linux/writer.rs
+++ b/src-tauri/src/flash/linux/writer.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Linux device writer. Uses UDisks2 (polkit auth) so the app can run as a
 //! normal user, falling back to a direct open when UDisks2 is unavailable.
 

--- a/src-tauri/src/flash/macos/authorization.rs
+++ b/src-tauri/src/flash/macos/authorization.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! macOS authorization requests and storage.
 
 use once_cell::sync::Lazy;

--- a/src-tauri/src/flash/macos/authorization.rs
+++ b/src-tauri/src/flash/macos/authorization.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! macOS authorization requests and storage.
 

--- a/src-tauri/src/flash/macos/bindings.rs
+++ b/src-tauri/src/flash/macos/bindings.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! C FFI bindings for macOS Security.framework authorization.
 

--- a/src-tauri/src/flash/macos/bindings.rs
+++ b/src-tauri/src/flash/macos/bindings.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! C FFI bindings for macOS Security.framework authorization.
 
 use std::ffi::c_void;

--- a/src-tauri/src/flash/macos/mod.rs
+++ b/src-tauri/src/flash/macos/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! macOS-specific flash implementation: Security.framework AuthorizationCreate + authopen `-extauth`
 //! for privilege escalation when writing to block devices.

--- a/src-tauri/src/flash/macos/mod.rs
+++ b/src-tauri/src/flash/macos/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! macOS-specific flash implementation: Security.framework AuthorizationCreate + authopen `-extauth`
 //! for privilege escalation when writing to block devices.
 

--- a/src-tauri/src/flash/macos/writer.rs
+++ b/src-tauri/src/flash/macos/writer.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! macOS device writer: opens devices via authopen authorization and writes data.
 
 use std::fs::File;

--- a/src-tauri/src/flash/macos/writer.rs
+++ b/src-tauri/src/flash/macos/writer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! macOS device writer: opens devices via authopen authorization and writes data.
 

--- a/src-tauri/src/flash/mod.rs
+++ b/src-tauri/src/flash/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Platform-specific image flashing: privilege escalation + raw device writing.
 //! macOS uses authopen (Touch ID), Linux uses pkexec, Windows needs Administrator.
 

--- a/src-tauri/src/flash/mod.rs
+++ b/src-tauri/src/flash/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Platform-specific image flashing: privilege escalation + raw device writing.
 //! macOS uses authopen (Touch ID), Linux uses pkexec, Windows needs Administrator.

--- a/src-tauri/src/flash/verify.rs
+++ b/src-tauri/src/flash/verify.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Shared verification logic for all platforms.
 

--- a/src-tauri/src/flash/verify.rs
+++ b/src-tauri/src/flash/verify.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Shared verification logic for all platforms.
 
 #![allow(dead_code)]

--- a/src-tauri/src/flash/windows.rs
+++ b/src-tauri/src/flash/windows.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Windows-specific flash implementation. Requires Administrator for raw disk access.
 
 use super::FlashState;

--- a/src-tauri/src/flash/windows.rs
+++ b/src-tauri/src/flash/windows.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Windows-specific flash implementation. Requires Administrator for raw disk access.
 

--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Map API response types into frontend-facing types. The REST API returns
 //! pre-processed data, so no extraction or deduplication is needed.
 

--- a/src-tauri/src/images/filters.rs
+++ b/src-tauri/src/images/filters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Map API response types into frontend-facing types. The REST API returns
 //! pre-processed data, so no extraction or deduplication is needed.

--- a/src-tauri/src/images/mod.rs
+++ b/src-tauri/src/images/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Fetching board, image, and vendor data from the Armbian REST API, with
 //! on-disk caching of responses for offline use.
 

--- a/src-tauri/src/images/mod.rs
+++ b/src-tauri/src/images/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Fetching board, image, and vendor data from the Armbian REST API, with
 //! on-disk caching of responses for offline use.

--- a/src-tauri/src/images/models.rs
+++ b/src-tauri/src/images/models.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Types representing Armbian API responses, boards, images, and vendors.
 

--- a/src-tauri/src/images/models.rs
+++ b/src-tauri/src/images/models.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Types representing Armbian API responses, boards, images, and vendors.
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Structured, formatted logging to the app's log directory, with timestamps
 //! and log level indicators.
 

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Structured, formatted logging to the app's log directory, with timestamps
 //! and log level indicators.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Armbian Imager: cross-platform Tauri app for downloading and flashing
 //! Armbian OS images to SD cards and USB drives.
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Armbian Imager: cross-platform Tauri app for downloading and flashing
 //! Armbian OS images to SD cards and USB drives.

--- a/src-tauri/src/paste/mod.rs
+++ b/src-tauri/src/paste/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Uploading application logs to paste.armbian.com for debugging and support.
 

--- a/src-tauri/src/paste/mod.rs
+++ b/src-tauri/src/paste/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Uploading application logs to paste.armbian.com for debugging and support.
 
 pub mod upload;

--- a/src-tauri/src/paste/upload.rs
+++ b/src-tauri/src/paste/upload.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Log upload to paste.armbian.com, a Hastebin instance accepting raw text via POST.
 

--- a/src-tauri/src/paste/upload.rs
+++ b/src-tauri/src/paste/upload.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Log upload to paste.armbian.com, a Hastebin instance accepting raw text via POST.
 
 use std::fs;

--- a/src-tauri/src/picture_cache.rs
+++ b/src-tauri/src/picture_cache.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Local disk cache for board images and vendor logos with ETag-based conditional refresh.
 //! Cache-first: serve local immediately, refresh stale entries in the background.

--- a/src-tauri/src/picture_cache.rs
+++ b/src-tauri/src/picture_cache.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Local disk cache for board images and vendor logos with ETag-based conditional refresh.
 //! Cache-first: serve local immediately, refresh stale entries in the background.
 

--- a/src-tauri/src/qdl/boards.rs
+++ b/src-tauri/src/qdl/boards.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Bundled fallback registry of per-board QDL/EDL facts, used when the Armbian API
 //! carries no `qdl` block for a board (offline, older API). The API is the primary source.
 

--- a/src-tauri/src/qdl/boards.rs
+++ b/src-tauri/src/qdl/boards.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Bundled fallback registry of per-board QDL/EDL facts, used when the Armbian API
 //! carries no `qdl` block for a board (offline, older API). The API is the primary source.

--- a/src-tauri/src/qdl/detect.rs
+++ b/src-tauri/src/qdl/detect.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! QDL device detection: scans for Qualcomm EDL-mode devices (VID 0x05c6, PID 0x9008) via the nusb
 //! pure-Rust USB library. Cross-platform: Linux (usbfs), macOS (IOKit), Windows (WinUSB).

--- a/src-tauri/src/qdl/detect.rs
+++ b/src-tauri/src/qdl/detect.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! QDL device detection: scans for Qualcomm EDL-mode devices (VID 0x05c6, PID 0x9008) via the nusb
 //! pure-Rust USB library. Cross-platform: Linux (usbfs), macOS (IOKit), Windows (WinUSB).
 

--- a/src-tauri/src/qdl/extract.rs
+++ b/src-tauri/src/qdl/extract.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! TAR archive extraction for QDL images. Archives contain flash/prog_firehose_ddr.elf (Sahara programmer),
 //! flash/rawprogram0.xml (partition instructions), flash/patch0.xml (post-flash patches), and partition images.

--- a/src-tauri/src/qdl/extract.rs
+++ b/src-tauri/src/qdl/extract.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! TAR archive extraction for QDL images. Archives contain flash/prog_firehose_ddr.elf (Sahara programmer),
 //! flash/rawprogram0.xml (partition instructions), flash/patch0.xml (post-flash patches), and partition images.
 

--- a/src-tauri/src/qdl/flash.rs
+++ b/src-tauri/src/qdl/flash.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! QDL flash orchestration: connect to EDL device via USB, upload firehose programmer via Sahara, configure
 //! Firehose and program partitions from rawprogram0.xml, apply patch0.xml patches, then reset the device.

--- a/src-tauri/src/qdl/flash.rs
+++ b/src-tauri/src/qdl/flash.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! QDL flash orchestration: connect to EDL device via USB, upload firehose programmer via Sahara, configure
 //! Firehose and program partitions from rawprogram0.xml, apply patch0.xml patches, then reset the device.
 

--- a/src-tauri/src/qdl/loader.rs
+++ b/src-tauri/src/qdl/loader.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Fetches and caches the Qualcomm firehose loader (`prog_firehose_ddr.elf`) for a
 //! board's SoC family from the armbian/qcombin repo, used to flash QDL/EDL devices.
 

--- a/src-tauri/src/qdl/loader.rs
+++ b/src-tauri/src/qdl/loader.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Fetches and caches the Qualcomm firehose loader (`prog_firehose_ddr.elf`) for a
 //! board's SoC family from the armbian/qcombin repo, used to flash QDL/EDL devices.

--- a/src-tauri/src/qdl/mod.rs
+++ b/src-tauri/src/qdl/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! QDL (Qualcomm Device Loader): flashing for boards using Qualcomm EDL (Emergency Download) mode instead of block-device
 //! writes. Uses the Sahara protocol to upload a firehose programmer, then the Firehose protocol to program partitions.
 

--- a/src-tauri/src/qdl/mod.rs
+++ b/src-tauri/src/qdl/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! QDL (Qualcomm Device Loader): flashing for boards using Qualcomm EDL (Emergency Download) mode instead of block-device
 //! writes. Uses the Sahara protocol to upload a firehose programmer, then the Firehose protocol to program partitions.

--- a/src-tauri/src/qdl/provision.rs
+++ b/src-tauri/src/qdl/provision.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Fetches the per-board UFS provisioning descriptor from qcombin and parses its `<ufs>`
 //! commands, used to set up a brand-new (unprovisioned) UFS module before the first write.
 

--- a/src-tauri/src/qdl/provision.rs
+++ b/src-tauri/src/qdl/provision.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Fetches the per-board UFS provisioning descriptor from qcombin and parses its `<ufs>`
 //! commands, used to set up a brand-new (unprovisioned) UFS module before the first write.

--- a/src-tauri/src/qdl/registry.rs
+++ b/src-tauri/src/qdl/registry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Resolves a board's QDL facts from the Armbian API (the served `qdl` block),
 //! falling back to the bundled default registry when the API has no metadata

--- a/src-tauri/src/qdl/registry.rs
+++ b/src-tauri/src/qdl/registry.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Resolves a board's QDL facts from the Armbian API (the served `qdl` block),
 //! falling back to the bundled default registry when the API has no metadata
 //! (offline, older API). The API is authoritative; the bundle keeps known

--- a/src-tauri/src/utils/format.rs
+++ b/src-tauri/src/utils/format.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Formatting helpers for human-readable output and Armbian filename parsing.
 

--- a/src-tauri/src/utils/format.rs
+++ b/src-tauri/src/utils/format.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Formatting helpers for human-readable output and Armbian filename parsing.
 
 pub const MB: u64 = 1024 * 1024;

--- a/src-tauri/src/utils/http.rs
+++ b/src-tauri/src/utils/http.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Shared builder for reqwest clients with the standard user agent.
 

--- a/src-tauri/src/utils/http.rs
+++ b/src-tauri/src/utils/http.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Shared builder for reqwest clients with the standard user agent.
 
 use std::path::Path;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Shared helpers for formatting, system info, path management, and progress
 //! tracking.
 

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! Shared helpers for formatting, system info, path management, and progress
 //! tracking.

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Path manipulation helpers used across the application.
 
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Path manipulation helpers used across the application.
 

--- a/src-tauri/src/utils/progress.rs
+++ b/src-tauri/src/utils/progress.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 //! Reusable progress tracker with speed calculation for download, flash,
 //! verification, SHA256, and decompression operations.

--- a/src-tauri/src/utils/progress.rs
+++ b/src-tauri/src/utils/progress.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! Reusable progress tracker with speed calculation for download, flash,
 //! verification, SHA256, and decompression operations.
 

--- a/src-tauri/src/utils/system.rs
+++ b/src-tauri/src/utils/system.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 //! System utilities: CPU info, cache/data paths, and platform detection.
 
 use std::path::PathBuf;

--- a/src-tauri/src/utils/system.rs
+++ b/src-tauri/src/utils/system.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 //! System utilities: CPU info, cache/data paths, and platform detection.
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "license": "GPL-2.0-or-later",
-    "copyright": "Copyright (c) 2025-2026 Armbian and Armbian Imager contributors",
+    "copyright": "Copyright (c) 2025-2026 Daniele Briguglio and contributors",
     "homepage": "https://github.com/armbian/imager",
     "publisher": "Armbian",
     "resources": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,13 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "license": "GPL-2.0-or-later",
+    "copyright": "Copyright (c) 2025-2026 Armbian and Armbian Imager contributors",
+    "homepage": "https://github.com/armbian/imager",
+    "publisher": "Armbian",
+    "resources": {
+      "../LICENSE": "LICENSE"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -78,7 +85,23 @@
     },
     "linux": {
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": false,
+        "files": {
+          "/usr/share/doc/armbian-imager/copyright": "packaging/copyright",
+          "/usr/share/doc/armbian-imager/LICENSE": "../LICENSE"
+        }
+      },
+      "deb": {
+        "section": "utils",
+        "files": {
+          "/usr/share/doc/armbian-imager/copyright": "packaging/copyright"
+        }
+      },
+      "rpm": {
+        "files": {
+          "/usr/share/doc/armbian-imager/copyright": "packaging/copyright",
+          "/usr/share/licenses/armbian-imager/LICENSE": "../LICENSE"
+        }
       }
     }
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Header, HomePage, WelcomePage } from './components/layout';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Armbian wordmark logos used as a faded watermark when a board photo is missing.
 // Light theme shows the black logo, dark theme the white one (CSS toggles visibility).
 export { default as BOARD_LOGO_LIGHT } from './armbian-logo-black.png';

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Armbian wordmark logos used as a faded watermark when a board photo is missing.
 // Light theme shows the black logo, dark theme the white one (CSS toggles visibility).

--- a/src/assets/os-logos/index.ts
+++ b/src/assets/os-logos/index.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
+// Copyright (c) 2026 Igor Pecovnik, igor@armbian.com
 
 import { OS_INFO } from '../../config/os-info';
 

--- a/src/assets/os-logos/index.ts
+++ b/src/assets/os-logos/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { OS_INFO } from '../../config/os-info';
 
 /** Resolve a human-readable OS name from a distro release string. */

--- a/src/components/flash/FlashActions.tsx
+++ b/src/components/flash/FlashActions.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/flash/FlashActions.tsx
+++ b/src/components/flash/FlashActions.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { FlashStage } from './FlashStageIcon';

--- a/src/components/flash/FlashPhaseDots.tsx
+++ b/src/components/flash/FlashPhaseDots.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { stagePhase, PHASE_ORDER, type FlashPhase, type FlashStage } from './FlashStageIcon';
 
 /** Active dot index for the current stage within the planned phases. */

--- a/src/components/flash/FlashPhaseDots.tsx
+++ b/src/components/flash/FlashPhaseDots.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { stagePhase, PHASE_ORDER, type FlashPhase, type FlashStage } from './FlashStageIcon';
 

--- a/src/components/flash/FlashProgress.tsx
+++ b/src/components/flash/FlashProgress.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { HardDrive, Usb, Disc, FileImage, ShieldOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/flash/FlashProgress.tsx
+++ b/src/components/flash/FlashProgress.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { HardDrive, Usb, Disc, FileImage, ShieldOff } from 'lucide-react';

--- a/src/components/flash/FlashStageIcon.tsx
+++ b/src/components/flash/FlashStageIcon.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import {
   Download,
   HardDrive,

--- a/src/components/flash/FlashStageIcon.tsx
+++ b/src/components/flash/FlashStageIcon.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import {
   Download,

--- a/src/components/flash/index.ts
+++ b/src/components/flash/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export { FlashProgress } from './FlashProgress';
 export { FlashActions } from './FlashActions';
 export { FlashStageIcon, getStageKey } from './FlashStageIcon';

--- a/src/components/flash/index.ts
+++ b/src/components/flash/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export { FlashProgress } from './FlashProgress';
 export { FlashActions } from './FlashActions';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export * from './layout';
 export * from './settings';
 export * from './modals';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export * from './layout';
 export * from './settings';

--- a/src/components/layout/BoardPanel.tsx
+++ b/src/components/layout/BoardPanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/layout/BoardPanel.tsx
+++ b/src/components/layout/BoardPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { ArrowRight } from 'lucide-react';

--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {

--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {
   RefreshCw, TriangleAlert, Shield, Usb, Lock, Cpu, ArrowRight, ChevronDown, Plus,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import armbianLogoWhite from '../../assets/armbian-logo-white.png';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, type ReactNode, type ComponentType } from 'react';
 import { Factory, Cpu, Database, HardDrive, Usb, FolderOpen, Archive, Check, ArrowRight, Lock, WifiOff } from 'lucide-react';

--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, type ReactNode, type ComponentType } from 'react';
 import { Factory, Cpu, Database, HardDrive, Usb, FolderOpen, Archive, Check, ArrowRight, Lock, WifiOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/layout/ManufacturerPanel.tsx
+++ b/src/components/layout/ManufacturerPanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBoards, getVendors } from '../../hooks/useTauri';

--- a/src/components/layout/ManufacturerPanel.tsx
+++ b/src/components/layout/ManufacturerPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/layout/OsPanel.tsx
+++ b/src/components/layout/OsPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useMemo } from 'react';
 import {

--- a/src/components/layout/OsPanel.tsx
+++ b/src/components/layout/OsPanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useMemo } from 'react';
 import {
   Package, Layers, Star, RefreshCw, AppWindow, Box,

--- a/src/components/layout/WelcomePage.tsx
+++ b/src/components/layout/WelcomePage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowRight } from 'lucide-react';

--- a/src/components/layout/WelcomePage.tsx
+++ b/src/components/layout/WelcomePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export { Header } from './Header';
 export { HomePage } from './HomePage';
 export { WelcomePage } from './WelcomePage';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export { Header } from './Header';
 export { HomePage } from './HomePage';

--- a/src/components/modals/ArmbianBoardModal.tsx
+++ b/src/components/modals/ArmbianBoardModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Modal shown on an Armbian host to confirm auto-selecting the detected board
 

--- a/src/components/modals/ArmbianBoardModal.tsx
+++ b/src/components/modals/ArmbianBoardModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Modal shown on an Armbian host to confirm auto-selecting the detected board
 
 import { useCallback, useEffect } from 'react';

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { type ReactNode, useEffect, useCallback } from 'react';
 import { X, ChevronLeft } from 'lucide-react';

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { type ReactNode, useEffect, useCallback } from 'react';
 import { X, ChevronLeft } from 'lucide-react';
 import { useModalExitAnimation } from '../../hooks/useModalExitAnimation';

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -1,2 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export { Modal } from './Modal';
 export { ArmbianBoardModal } from './ArmbianBoardModal';

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export { Modal } from './Modal';
 export { ArmbianBoardModal } from './ArmbianBoardModal';

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getVersion } from '@tauri-apps/api/app';

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Monitor, Moon, Search, Sun } from 'lucide-react';

--- a/src/components/settings/AutoconfigSection.tsx
+++ b/src/components/settings/AutoconfigSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {

--- a/src/components/settings/AutoconfigSection.tsx
+++ b/src/components/settings/AutoconfigSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/CacheManagerModal.tsx
+++ b/src/components/settings/CacheManagerModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Cache manager sub-modal: master-detail (boards in left rail, selected board's cached images on right).
 // Frozen `cache-*` vocabulary; glass restyle lives in settings.css.

--- a/src/components/settings/CacheManagerModal.tsx
+++ b/src/components/settings/CacheManagerModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Cache manager sub-modal: master-detail (boards in left rail, selected board's cached images on right).
 // Frozen `cache-*` vocabulary; glass restyle lives in settings.css.
 

--- a/src/components/settings/DeveloperSection.tsx
+++ b/src/components/settings/DeveloperSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronRight, Code, FileText } from 'lucide-react';

--- a/src/components/settings/DeveloperSection.tsx
+++ b/src/components/settings/DeveloperSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/LogsModal.tsx
+++ b/src/components/settings/LogsModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/components/settings/LogsModal.tsx
+++ b/src/components/settings/LogsModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/PreferencesSection.tsx
+++ b/src/components/settings/PreferencesSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Lightbulb, Download, ShieldOff, Cpu, Sparkles, WifiOff, ShieldAlert } from 'lucide-react';

--- a/src/components/settings/PreferencesSection.tsx
+++ b/src/components/settings/PreferencesSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/SettingsButton.tsx
+++ b/src/components/settings/SettingsButton.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Settings } from 'lucide-react';

--- a/src/components/settings/SettingsButton.tsx
+++ b/src/components/settings/SettingsButton.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/components/settings/StorageSection.tsx
+++ b/src/components/settings/StorageSection.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HardDrive, Database, Trash2, FolderOpen, ChevronRight } from 'lucide-react';

--- a/src/components/settings/StorageSection.tsx
+++ b/src/components/settings/StorageSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export { SettingsModal } from './SettingsModal';
 export { SettingsButton } from './SettingsButton';
 export { AppearanceSection } from './AppearanceSection';

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export { SettingsModal } from './SettingsModal';
 export { SettingsButton } from './SettingsButton';

--- a/src/components/shared/BoardBadges.tsx
+++ b/src/components/shared/BoardBadges.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Support tier badges (Platinum, Standard, Community, EOS, TV Box, WIP)
 
 import { Crown, Shield, Users, Clock, Tv, Wrench } from 'lucide-react';

--- a/src/components/shared/BoardBadges.tsx
+++ b/src/components/shared/BoardBadges.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Support tier badges (Platinum, Standard, Community, EOS, TV Box, WIP)
 

--- a/src/components/shared/BoardImage.tsx
+++ b/src/components/shared/BoardImage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState } from 'react';
 import { BOARD_LOGO_LIGHT, BOARD_LOGO_DARK } from '../../assets';
 

--- a/src/components/shared/BoardImage.tsx
+++ b/src/components/shared/BoardImage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState } from 'react';
 import { BOARD_LOGO_LIGHT, BOARD_LOGO_DARK } from '../../assets';

--- a/src/components/shared/ChangelogModal.tsx
+++ b/src/components/shared/ChangelogModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo } from 'react';
 import { X, FileText, ExternalLink, Calendar, Loader2, Users } from 'lucide-react';

--- a/src/components/shared/ChangelogModal.tsx
+++ b/src/components/shared/ChangelogModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo } from 'react';
 import { X, FileText, ExternalLink, Calendar, Loader2, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/shared/ConfirmationDialog.tsx
+++ b/src/components/shared/ConfirmationDialog.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Reusable confirmation dialog
 
 import type { ReactNode } from 'react';

--- a/src/components/shared/ConfirmationDialog.tsx
+++ b/src/components/shared/ConfirmationDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Reusable confirmation dialog
 

--- a/src/components/shared/DeviceIcon.tsx
+++ b/src/components/shared/DeviceIcon.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { HardDrive, Lock, MemoryStick, Usb } from 'lucide-react';
 import type { DeviceType } from '../../config';
 

--- a/src/components/shared/DeviceIcon.tsx
+++ b/src/components/shared/DeviceIcon.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { HardDrive, Lock, MemoryStick, Usb } from 'lucide-react';
 import type { DeviceType } from '../../config';

--- a/src/components/shared/ErrorDisplay.tsx
+++ b/src/components/shared/ErrorDisplay.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState } from 'react';
 import { Upload, ExternalLink, CircleAlert, CircleX, Loader2, ArrowRight, RotateCcw } from 'lucide-react';

--- a/src/components/shared/ErrorDisplay.tsx
+++ b/src/components/shared/ErrorDisplay.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState } from 'react';
 import { Upload, ExternalLink, CircleAlert, CircleX, Loader2, ArrowRight, RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/shared/GridPager.tsx
+++ b/src/components/shared/GridPager.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 interface GridPagerProps {
   pageCount: number;
   page: number;

--- a/src/components/shared/GridPager.tsx
+++ b/src/components/shared/GridPager.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 interface GridPagerProps {
   pageCount: number;

--- a/src/components/shared/MarqueeText.tsx
+++ b/src/components/shared/MarqueeText.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useRef, useEffect, useState } from 'react';
 import { UI } from '../../config';
 

--- a/src/components/shared/MarqueeText.tsx
+++ b/src/components/shared/MarqueeText.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useRef, useEffect, useState } from 'react';
 import { UI } from '../../config';

--- a/src/components/shared/MotdTip.tsx
+++ b/src/components/shared/MotdTip.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Lightbulb, ExternalLink } from 'lucide-react';

--- a/src/components/shared/MotdTip.tsx
+++ b/src/components/shared/MotdTip.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Lightbulb, ExternalLink } from 'lucide-react';
 import { openUrl } from '../../hooks/useTauri';

--- a/src/components/shared/SearchBox.tsx
+++ b/src/components/shared/SearchBox.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Reusable search input for modal dialogs
 

--- a/src/components/shared/SearchBox.tsx
+++ b/src/components/shared/SearchBox.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Reusable search input for modal dialogs
 
 import { Search } from 'lucide-react';

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Auto-dismissing success/error notification toast
 
 import { useState, useEffect } from 'react';

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Auto-dismissing success/error notification toast
 

--- a/src/components/shared/UpdateEntry.tsx
+++ b/src/components/shared/UpdateEntry.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useUpdate } from '../../contexts/UpdateContext';

--- a/src/components/shared/UpdateEntry.tsx
+++ b/src/components/shared/UpdateEntry.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/shared/UpdateModal.tsx
+++ b/src/components/shared/UpdateModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 import { Download, RefreshCw, CircleCheck, CircleAlert, X, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/shared/UpdateModal.tsx
+++ b/src/components/shared/UpdateModal.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 import { Download, RefreshCw, CircleCheck, CircleAlert, X, FileText } from 'lucide-react';

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Shared components exports
 

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Shared components exports
 
 export { BoardBadges } from './BoardBadges';

--- a/src/config/autoconfig.ts
+++ b/src/config/autoconfig.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Static option data for the autoconfig profile editor dropdowns.
 
 import type { AutoconfigConfig, UserShell } from '../types';

--- a/src/config/autoconfig.ts
+++ b/src/config/autoconfig.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Static option data for the autoconfig profile editor dropdowns.
 

--- a/src/config/badges.ts
+++ b/src/config/badges.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Badge configuration for desktop environments and kernel types */
 
 import { PALETTE } from './constants';

--- a/src/config/badges.ts
+++ b/src/config/badges.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
+// Copyright (c) 2026 Igor Pecovnik, igor@armbian.com
 
 /** Badge configuration for desktop environments and kernel types */
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 /** Application constants and configuration values */
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Application constants and configuration values */
 
 /** Polling intervals in milliseconds */

--- a/src/config/deviceColors.ts
+++ b/src/config/deviceColors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Color configuration per storage device type for visual distinction */
 
 import { PALETTE } from './constants';

--- a/src/config/deviceColors.ts
+++ b/src/config/deviceColors.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 /** Color configuration per storage device type for visual distinction */
 

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Supported-language config. To add one: drop src/locales/{code}.json and add an entry below.
 
 // Twemoji flag SVGs from the maintained @twemoji/svg package; Vite bundles only these

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
+// Copyright (c) 2026 Ricardo Pardini, ricardo@pardini.net
 
 // Supported-language config. To add one: drop src/locales/{code}.json and add an entry below.
 

--- a/src/config/imageFilters.ts
+++ b/src/config/imageFilters.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /** Image filtering predicates and filter button definitions shared by image selection UIs */
 

--- a/src/config/imageFilters.ts
+++ b/src/config/imageFilters.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Image filtering predicates and filter button definitions shared by image selection UIs */
 
 import { Star, Shield, RefreshCw, AppWindow, Box } from 'lucide-react';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Configuration exports
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Configuration exports
 
 // OS/App information

--- a/src/config/mono-logos.ts
+++ b/src/config/mono-logos.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /**
  * Monochrome (single-path, transparent-cutout) logo set used across the app for OS/app marks:
  * the OsPanel split cards force them to a white silhouette over the distro gradient, while the

--- a/src/config/mono-logos.ts
+++ b/src/config/mono-logos.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /**
  * Monochrome (single-path, transparent-cutout) logo set used across the app for OS/app marks:

--- a/src/config/os-info.ts
+++ b/src/config/os-info.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** OS/Distro information configuration */
 
 import type { ImageInfo } from '../types';

--- a/src/config/os-info.ts
+++ b/src/config/os-info.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
+// Copyright (c) 2026 Igor Pecovnik, igor@armbian.com
 
 /** OS/Distro information configuration */
 

--- a/src/config/qdlBoards.ts
+++ b/src/config/qdlBoards.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /** i18n key for the EDL-entry hint, from the backend-resolved method (defaults to jumper). */
 export function qdlInstructionsKey(edlEntry?: string | null): string {

--- a/src/config/qdlBoards.ts
+++ b/src/config/qdlBoards.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** i18n key for the EDL-entry hint, from the backend-resolved method (defaults to jumper). */
 export function qdlInstructionsKey(edlEntry?: string | null): string {
   return edlEntry === 'button' ? 'device.qdlInstructionsButton' : 'device.qdlInstructions';

--- a/src/config/supportTiers.ts
+++ b/src/config/supportTiers.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Support tier identifiers, labels, and ordering shared across panels and modals */
 
 /** Canonical support tier identifiers */

--- a/src/config/supportTiers.ts
+++ b/src/config/supportTiers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /** Support tier identifiers, labels, and ordering shared across panels and modals */
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import { getTheme, setTheme as saveTheme } from '../hooks/useSettings';
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import { getTheme, setTheme as saveTheme } from '../hooks/useSettings';

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { logInfo } from '../hooks/useTauri';

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 import { check, type Update } from '@tauri-apps/plugin-updater';

--- a/src/hooks/useAsyncData.ts
+++ b/src/hooks/useAsyncData.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getErrorMessage } from '../utils';
 

--- a/src/hooks/useAsyncData.ts
+++ b/src/hooks/useAsyncData.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getErrorMessage } from '../utils';

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Poll backend connectivity every 30s; starts optimistic (online) until the first check.
 // When the force_offline setting is enabled, the hook reports offline regardless of real connectivity.

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Poll backend connectivity every 30s; starts optimistic (online) until the first check.
 // When the force_offline setting is enabled, the hook reports offline regardless of real connectivity.
 

--- a/src/hooks/useDeviceMonitor.ts
+++ b/src/hooks/useDeviceMonitor.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useEffect, useCallback } from 'react';
 import { getBlockDevices, getQdlDevices } from './useTauri';
 import { POLLING } from '../config';

--- a/src/hooks/useDeviceMonitor.ts
+++ b/src/hooks/useDeviceMonitor.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useEffect, useCallback } from 'react';
 import { getBlockDevices, getQdlDevices } from './useTauri';

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Drives the full flash lifecycle: authorize, download, decompress, flash, verify, cleanup
 

--- a/src/hooks/useFlashOperation.ts
+++ b/src/hooks/useFlashOperation.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Drives the full flash lifecycle: authorize, download, decompress, flash, verify, cleanup
 
 import { useState, useEffect, useRef, useCallback } from 'react';

--- a/src/hooks/useModalExitAnimation.ts
+++ b/src/hooks/useModalExitAnimation.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Consistent modal exit animation with double-trigger guard and pre/post-close callbacks
 
 import { useState, useCallback, useRef } from 'react';

--- a/src/hooks/useModalExitAnimation.ts
+++ b/src/hooks/useModalExitAnimation.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Consistent modal exit animation with double-trigger guard and pre/post-close callbacks
 

--- a/src/hooks/usePagedGrid.ts
+++ b/src/hooks/usePagedGrid.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 

--- a/src/hooks/usePagedGrid.ts
+++ b/src/hooks/usePagedGrid.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 
 /** Default upper bound, sized to avoid loading too many heavy cards (board

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 // Persistent settings access via the Tauri Store plugin (no backend commands)
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Persistent settings access via the Tauri Store plugin (no backend commands)
 
 import { load } from '@tauri-apps/plugin-store';

--- a/src/hooks/useSettingsGroup.ts
+++ b/src/hooks/useSettingsGroup.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Load several settings together on mount with shared error handling
 
 import { useEffect, useState } from 'react';

--- a/src/hooks/useSettingsGroup.ts
+++ b/src/hooks/useSettingsGroup.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Load several settings together on mount with shared error handling
 

--- a/src/hooks/useSkeletonLoading.ts
+++ b/src/hooks/useSkeletonLoading.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect } from 'react';
 
 /** Skeleton loading with a min visibility window to avoid flicker: shows on load, hides

--- a/src/hooks/useSkeletonLoading.ts
+++ b/src/hooks/useSkeletonLoading.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect } from 'react';
 

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { invoke } from '@tauri-apps/api/core';
 import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, CustomImageClassification, ArmbianReleaseInfo, CachedImageInfo, CacheBreakdown, QdlDevice, VendorInfo, AutoconfigConfig } from '../types';
 

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { invoke } from '@tauri-apps/api/core';
 import type { BoardInfo, ImageInfo, BlockDevice, DownloadProgress, FlashProgress, CustomImageInfo, CustomImageClassification, ArmbianReleaseInfo, CachedImageInfo, CacheBreakdown, QdlDevice, VendorInfo, AutoconfigConfig } from '../types';

--- a/src/hooks/useToasts.tsx
+++ b/src/hooks/useToasts.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Global toast system via React Context: one shared container, accessed through useToasts()
 
 import { createContext, useContext, useState, useCallback } from 'react';

--- a/src/hooks/useToasts.tsx
+++ b/src/hooks/useToasts.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Global toast system via React Context: one shared container, accessed through useToasts()
 

--- a/src/hooks/useVendorLogos.ts
+++ b/src/hooks/useVendorLogos.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { BoardInfo } from '../types';

--- a/src/hooks/useVendorLogos.ts
+++ b/src/hooks/useVendorLogos.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { BoardInfo } from '../types';
 import { getCachedVendorLogo } from './useTauri';

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
+// Copyright (c) 2025 Igor Pecovnik, igor@armbian.com
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 export interface BoardInfo {
   slug: string;
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 export interface BoardInfo {
   slug: string;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Parse a hex color (#rgb or #rrggbb) into its red/green/blue components. */
 export function hexToRgb(hex: string): { r: number; g: number; b: number } {
   let value = hex.replace('#', '');

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /** Parse a hex color (#rgb or #rrggbb) into its red/green/blue components. */
 export function hexToRgb(hex: string): { r: number; g: number; b: number } {

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import type { BlockDevice, QdlDevice } from '../types';
 import type { DeviceType } from '../config/constants';

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import type { BlockDevice, QdlDevice } from '../types';
 import type { DeviceType } from '../config/constants';
 

--- a/src/utils/distroTheme.ts
+++ b/src/utils/distroTheme.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /** Distro-based theming helpers: gradients, accent colour and per-card CSS variables. */
 
 import type { CSSProperties } from 'react';

--- a/src/utils/distroTheme.ts
+++ b/src/utils/distroTheme.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 /** Distro-based theming helpers: gradients, accent colour and per-card CSS variables. */
 

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 // Parse the backend's tagged error strings (e.g. [SHA_UNAVAILABLE]) and map them to i18n keys
 
 import { formatBytes } from './index';

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2026 Daniele Briguglio, superkali@armbian.com
 
 // Parse the backend's tagged error strings (e.g. [SHA_UNAVAILABLE]) and map them to i18n keys
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 import { COLORS, UI, SLUGS, SUPPORT_TIER_ORDER } from '../config';
 import { getImageVariantLabel, getOsInfo } from '../config/os-info';
 import { getDesktopEnv, DESKTOP_BADGES } from '../config/badges';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 import { COLORS, UI, SLUGS, SUPPORT_TIER_ORDER } from '../config';
 import { getImageVariantLabel, getOsInfo } from '../config/os-info';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+
 /// <reference types="vite/client" />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025-2026 Armbian and Armbian Imager contributors
+// Copyright (c) 2025-2026 Daniele Briguglio, superkali@armbian.com
 
 /// <reference types="vite/client" />


### PR DESCRIPTION
The repo had the GPLv2 text but never said which variant applied, so packagers had to guess and the published winget manifest picked up the deprecated GPL-2.0 identifier. This declares GPL-2.0-or-later in the README and in Cargo.toml, package.json and bundle.license, where the tooling looks. The deb, rpm and AppImage now ship the license text and a DEP-5 copyright file, which none of them had, and the sources get SPDX headers like the build framework's.

I picked or-later over only because the binary statically links Apache-2.0 crates, notably tao under Tauri, and Apache-2.0 does not work under GPLv2 but does under GPLv3. Version 2 is still the floor, so nothing changes towards the build framework. The copyright file also credits the bundled Twemoji flags, which are CC-BY-4.0.

@igorpecovnik adding "or later" widens the grant, so it needs your ack. If you would rather stay literal with the framework's GPL-2.0 header, going back to GPL-2.0-only is a one line change.

Closes #180
