### PR TITLE
feat(flash): show the kernel version in the confirm summary

### DIFF
--- a/src/components/layout/DevicePanel.tsx
+++ b/src/components/layout/DevicePanel.tsx
@@ -34,7 +34,7 @@ interface DevicePanelProps {
   /** EDL-entry hint ("button"/"jumper") for the selected board, drives the QDL instructions. */
   edlEntry?: string | null;
   /** Upstream selections (manufacturer/board/OS) shown in the confirm summary. */
-  summary?: { label: string; value: string }[];
+  summary?: { label: string; value: string; sub?: string | null }[];
   /** Cached board photo shown at the top of the confirm summary. */
   boardImage?: string | null;
   /** Whether autoconfig profiles apply (Armbian images only; hidden for generic custom images). */
@@ -221,8 +221,11 @@ export function DevicePanel({
                 {summary.map((row) => (
                   <li key={row.label} className="device-summary__row">
                     <span className="device-summary__label">{row.label}</span>
-                    {/* Long values (e.g. custom image filenames) auto-scroll instead of truncating. */}
-                    <MarqueeText text={row.value} className="device-summary__value" maxWidth={340} />
+                    <span className="device-summary__valueinfo">
+                      {/* Long values (e.g. custom image filenames) auto-scroll instead of truncating. */}
+                      <MarqueeText text={row.value} className="device-summary__value" maxWidth={340} />
+                      {row.sub && <span className="device-summary__sub">{row.sub}</span>}
+                    </span>
                   </li>
                 ))}
                 {/* Target device as a label/value row, consistent with the rows above. */}

--- a/src/components/layout/HomePage.tsx
+++ b/src/components/layout/HomePage.tsx
@@ -6,7 +6,7 @@ import { Factory, Cpu, Database, HardDrive, Usb, FolderOpen, Archive, Check, Arr
 import { useTranslation } from 'react-i18next';
 import { getCachedBoardImage } from '../../hooks/useTauri';
 import { IMAGE_VARIANT } from '../../config';
-import { isDetectedBoard, formatImageIdentity } from '../../utils';
+import { isDetectedBoard, formatImageIdentity, formatKernelLabel } from '../../utils';
 import type { BoardInfo, ImageInfo, BlockDevice, Manufacturer } from '../../types';
 import { deriveFlashMethod, isEdlImage } from '../../types';
 import { MarqueeText, MotdTip, BoardImage, UpdateEntry } from '../shared';
@@ -259,8 +259,12 @@ export function HomePage({
   const deviceSummary = [
     selectedManufacturer && { label: t('home.manufacturer'), value: selectedManufacturer.name },
     selectedBoard && { label: t('home.board'), value: selectedBoard.name },
-    selectedImage && { label: t('home.operatingSystem'), value: osLabelText(selectedImage, t) },
-  ].filter(Boolean) as { label: string; value: string }[];
+    selectedImage && {
+      label: t('home.operatingSystem'),
+      value: osLabelText(selectedImage, t),
+      sub: formatKernelLabel(selectedImage),
+    },
+  ].filter(Boolean) as { label: string; value: string; sub?: string | null }[];
 
   // Inline storage panel; it picks list vs. confirm view from `selectedDevice`.
   const renderDevicePanel = () => (

--- a/src/components/layout/OsPanel.tsx
+++ b/src/components/layout/OsPanel.tsx
@@ -16,7 +16,7 @@ import {
   isTrunkImage, IMAGE_FILTER_PREDICATES, FILTER_BUTTONS, categoryOf, type OsCategory,
 } from '../../config';
 import { getMonoLogo } from '../../config/mono-logos';
-import { formatFileSize, hexToRgba, staggerDelay, splitArmbianVersion, formatDate, armbianIdentityKey } from '../../utils';
+import { formatFileSize, hexToRgba, staggerDelay, splitArmbianVersion, formatDate, armbianIdentityKey, formatKernelLabel } from '../../utils';
 import { distroGradient, distroBlock, distroVars } from '../../utils/distroTheme';
 import { ErrorDisplay, ConfirmationDialog } from '../shared';
 import type { BoardInfo, ImageInfo, ImageFilterType, CachedImageInfo } from '../../types';
@@ -208,7 +208,7 @@ export function OsPanel({ board, onSelect }: OsPanelProps) {
             {(kernelBadge || image.kernel_branch) && (
               <span className="dl-card__kernel">
                 <span className="dl-dot" style={{ background: kernelBadge?.color ?? '#10b981' }} />
-                {kernelBadge?.label ?? image.kernel_branch}{image.kernel_version ? ` ${image.kernel_version}` : ''}
+                {formatKernelLabel(image)}
               </span>
             )}
             {image.storage?.toLowerCase() === 'ufs' && (
@@ -266,7 +266,7 @@ export function OsPanel({ board, onSelect }: OsPanelProps) {
               {kernelBadge && (
                 <SoftBadge
                   color={kernelBadge.color}
-                  label={`${kernelBadge.label}${image.kernel_version ? ` ${image.kernel_version}` : ''}`}
+                  label={formatKernelLabel(image) ?? kernelBadge.label}
                 />
               )}
               {image.storage?.toLowerCase() === 'ufs' && <SoftBadge color="#f59e0b" label="UFS" />}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1715,6 +1715,19 @@
   color: var(--text-muted);
 }
 
+.device-summary__valueinfo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 0;
+}
+
+.device-summary__sub {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 .device-summary__value {
   font-size: 13.5px;
   font-weight: 600;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@
 
 import { COLORS, UI, SLUGS, SUPPORT_TIER_ORDER } from '../config';
 import { getImageVariantLabel, getOsInfo } from '../config/os-info';
-import { getDesktopEnv, DESKTOP_BADGES } from '../config/badges';
+import { getDesktopEnv, DESKTOP_BADGES, getKernelType, KERNEL_BADGES } from '../config/badges';
 import type { ImageInfo } from '../types';
 
 // Re-export color helpers from the dedicated color module
@@ -224,6 +224,13 @@ export function formatImageIdentity(
     title: `Armbian ${version} ${getImageVariantLabel(image, t)}`.replace(/\s+/g, ' ').trim(),
     meta: meta || null,
   };
+}
+
+/** Kernel branch label plus version, e.g. "Current 6.12.35"; null when the image carries neither. */
+export function formatKernelLabel(image: ImageInfo): string | null {
+  const type = getKernelType(image.kernel_branch);
+  const label = type ? KERNEL_BADGES[type].label : image.kernel_branch;
+  return `${label ?? ''} ${image.kernel_version ?? ''}`.trim() || null;
 }
 
 /** Extract a message from an unknown error value, using `fallback` if none found */


### PR DESCRIPTION
The confirm summary named the OS but not the kernel, which is the other thing worth a look before erasing a card. The operating system row now carries the branch label and version on a sub-line, the same shape the storage row below it already uses, so it needed no new translation keys.

OsPanel had the same branch-plus-version expression open-coded twice and this would have been a third copy, so it moved into a shared `formatKernelLabel` helper that all three call sites go through. It falls back to the raw branch when the badge is unknown and returns null when the image carries neither, in which case the sub-line simply does not render.
