### PR TITLE
fix(images): label server and bianbu variants instead of calling them minimal

### DIFF
--- a/src/components/settings/CacheManagerModal.tsx
+++ b/src/components/settings/CacheManagerModal.tsx
@@ -19,7 +19,7 @@ import { EVENTS } from '../../config';
 import { getOsInfo } from '../../config/os-info';
 import { getMonoLogo } from '../../config/mono-logos';
 import { distroBlock } from '../../utils/distroTheme';
-import { getDesktopEnv, getKernelType, DESKTOP_BADGES, KERNEL_BADGES, adjustBrightness } from '../../config/badges';
+import { getDesktopEnv, getVariantBadge, getKernelType, KERNEL_BADGES, adjustBrightness } from '../../config/badges';
 import type { CachedImageInfo, BoardInfo } from '../../types';
 
 interface CacheManagerModalProps {
@@ -309,6 +309,7 @@ export function CacheManagerModal({ isOpen, onClose }: CacheManagerModalProps) {
                       const osInfo = parsed?.distro ? getOsInfo(parsed.distro) : null;
                       const monoLogo = getMonoLogo(parsed?.distro ?? '', parsed?.desktop);
                       const desktopEnv = parsed?.desktop ? getDesktopEnv(parsed.desktop) : null;
+                      const variantBadge = getVariantBadge(parsed?.desktop);
                       const kernelType = parsed?.branch ? getKernelType(parsed.branch) : null;
                       const badgeConfig = kernelType ? KERNEL_BADGES[kernelType] : null;
                       const isUfs = !!parsed?.kernel && parsed.kernel.toLowerCase().endsWith('-ufs');
@@ -344,7 +345,7 @@ export function CacheManagerModal({ isOpen, onClose }: CacheManagerModalProps) {
                             </div>
 
                             <div className="image-info-side-panel">
-                              {desktopEnv && DESKTOP_BADGES[desktopEnv] ? (
+                              {desktopEnv && variantBadge ? (
                                 <div
                                   className="side-info-badge"
                                   style={{
@@ -355,7 +356,7 @@ export function CacheManagerModal({ isOpen, onClose }: CacheManagerModalProps) {
                                   }}
                                 >
                                   <Monitor size={11} />
-                                  <span>{DESKTOP_BADGES[desktopEnv].label}</span>
+                                  <span>{variantBadge.label}</span>
                                 </div>
                               ) : (
                                 <div
@@ -368,7 +369,7 @@ export function CacheManagerModal({ isOpen, onClose }: CacheManagerModalProps) {
                                   }}
                                 >
                                   <Terminal size={11} />
-                                  <span>CLI</span>
+                                  <span>{variantBadge?.label ?? 'CLI'}</span>
                                 </div>
                               )}
                               {badgeConfig && (

--- a/src/config/badges.ts
+++ b/src/config/badges.ts
@@ -14,6 +14,7 @@ export interface BadgeConfig {
 /** Desktop environment badges */
 export const DESKTOP_BADGES: Record<string, BadgeConfig> = {
   'gnome': { label: 'GNOME', color: '#4a86cf' },
+  'kde-neon': { label: 'KDE Neon', color: '#2eb398' },
   'kde': { label: 'KDE', color: '#1d99f3' },
   'xfce': { label: 'XFCE', color: '#2284f2' },
   'cinnamon': { label: 'Cinnamon', color: '#dc682e' },
@@ -23,6 +24,12 @@ export const DESKTOP_BADGES: Record<string, BadgeConfig> = {
   'lxqt': { label: 'LXQt', color: '#0192d3' },
   'i3': { label: 'i3WM', color: '#1a8cff' },
   'sway': { label: 'Sway', color: '#68b0d8' },
+  'bianbu': { label: 'Bianbu', color: PALETTE.CYAN },
+};
+
+/** Variants that are not desktop environments; kept apart so they stay out of the desktop filter. */
+export const VARIANT_BADGES: Record<string, BadgeConfig> = {
+  'server': { label: 'Server', color: PALETTE.SLATE },
 };
 
 /** Kernel type badges */
@@ -39,11 +46,28 @@ export const KERNEL_BADGES: Record<string, BadgeConfig> = {
 /** Desktop environment keys, used for filtering */
 export const DESKTOP_ENVIRONMENTS = Object.keys(DESKTOP_BADGES);
 
+// Longest key first, so 'kde-neon' wins over the 'kde' substring it contains.
+const BY_SPECIFICITY = (keys: string[]) => [...keys].sort((a, b) => b.length - a.length);
+const DESKTOP_MATCH = BY_SPECIFICITY(DESKTOP_ENVIRONMENTS);
+const VARIANT_MATCH = BY_SPECIFICITY(Object.keys(VARIANT_BADGES));
+
 /** Get the desktop environment from a variant string */
 export function getDesktopEnv(variant: string): string | null {
   const v = variant.toLowerCase();
-  for (const key of DESKTOP_ENVIRONMENTS) {
+  for (const key of DESKTOP_MATCH) {
     if (v.includes(key)) return key;
+  }
+  return null;
+}
+
+/** Badge for an image variant: a desktop environment first, then the non-desktop variants. */
+export function getVariantBadge(variant: string | null | undefined): BadgeConfig | null {
+  if (!variant) return null;
+  const desktop = getDesktopEnv(variant);
+  if (desktop) return DESKTOP_BADGES[desktop];
+  const v = variant.toLowerCase();
+  for (const key of VARIANT_MATCH) {
+    if (v.includes(key)) return VARIANT_BADGES[key];
   }
   return null;
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,9 +17,11 @@ export {
 // Badge configuration
 export {
   DESKTOP_BADGES,
+  VARIANT_BADGES,
   KERNEL_BADGES,
   DESKTOP_ENVIRONMENTS,
   getDesktopEnv,
+  getVariantBadge,
   getKernelType,
   adjustBrightness,
   type BadgeConfig,

--- a/src/config/os-info.ts
+++ b/src/config/os-info.ts
@@ -5,7 +5,7 @@
 /** OS/Distro information configuration */
 
 import type { ImageInfo } from '../types';
-import { getDesktopEnv, DESKTOP_BADGES } from './badges';
+import { getVariantBadge } from './badges';
 
 export interface OsInfoConfig {
   name: string;
@@ -77,8 +77,5 @@ export function getImageVariantLabel(image: ImageInfo, t: (key: string) => strin
   const appInfo = getAppInfo(image.preinstalled_application);
   if (appInfo) return appInfo.badge ?? appInfo.name;
 
-  const desktopEnv = getDesktopEnv(image.image_variant);
-  if (desktopEnv && DESKTOP_BADGES[desktopEnv]) return DESKTOP_BADGES[desktopEnv].label;
-
-  return t('modal.minimal');
+  return getVariantBadge(image.image_variant)?.label ?? t('modal.minimal');
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@
 
 import { COLORS, UI, SLUGS, SUPPORT_TIER_ORDER } from '../config';
 import { getImageVariantLabel, getOsInfo } from '../config/os-info';
-import { getDesktopEnv, DESKTOP_BADGES, getKernelType, KERNEL_BADGES } from '../config/badges';
+import { getVariantBadge, getKernelType, KERNEL_BADGES } from '../config/badges';
 import type { ImageInfo } from '../types';
 
 // Re-export color helpers from the dedicated color module
@@ -203,9 +203,7 @@ export function formatImageIdentity(
     const parsed = parseArmbianFilename(image.distro_release || '');
     if (parsed?.version) {
       const version = splitArmbianVersion(parsed.version).base;
-      const desktopEnv = parsed.desktop ? getDesktopEnv(parsed.desktop) : null;
-      const variant =
-        desktopEnv && DESKTOP_BADGES[desktopEnv] ? DESKTOP_BADGES[desktopEnv].label : t('modal.minimal');
+      const variant = getVariantBadge(parsed.desktop)?.label ?? t('modal.minimal');
       const os = parsed.distro ? getOsInfo(parsed.distro)?.name ?? null : null;
       return {
         title: `Armbian ${version} ${variant}`.replace(/\s+/g, ' ').trim(),


### PR DESCRIPTION
Any variant the config did not recognise fell through to the "minimal" label, and two real ones were landing there: `server` with 269 images and `bianbu` with 4 on the SpacemiT RISC-V boards. Server and minimal are different products, so a sixth of the catalogue was mislabelled. `kde-neon` had a milder version of it, matching the `kde` substring and showing as plain KDE.

The two fixes are not the same. Bianbu joins the desktop environments, which is right because the files are `bianbu_desktop`, so it also classifies as a desktop in the image filters. Server gets a map of its own, otherwise those 269 images would start appearing under the desktop filter. Matching is now longest-key-first, so `kde-neon` beats `kde` regardless of declaration order.

The same fallback was open-coded in three places and this would have been a fourth, so it moved into a shared `getVariantBadge`. In the cache manager a server image now reads "Server" instead of "CLI", still on the terminal side.
